### PR TITLE
サブホーム機能を実装（MySQL別スレッド対応）

### DIFF
--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,12 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # SeichiAssist
-##動作環境
+##開発環境
 java 1.8
 spigot 1.10.2
+mysql-connecter-java-5.1.35
 ##前提プラグイン
--CoreProtect_2.12.0
+CoreProtect_2.12.0
+worldedit-6.1.3
+worldguard-6.1.2
+ParticleAPI_v2.1.1
+Zenchantments1.9-1.10

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# SeichiAssist
+##動作環境
+java 1.8
+spigot 1.10.2
+##前提プラグイン
+-CoreProtect_2.12.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # SeichiAssist
 ##開発環境
-java 1.8
-spigot 1.10.2
-mysql-connecter-java-5.1.35
+java 1.8<br>
+spigot 1.10.2<br>
+mysql-connecter-java-5.1.35<br>
 ##前提プラグイン
-CoreProtect_2.12.0
-worldedit-6.1.3
-worldguard-6.1.2
-ParticleAPI_v2.1.1
-Zenchantments1.9-1.10
+CoreProtect_2.12.0<br>
+worldedit-6.1.3<br>
+worldguard-6.1.2<br>
+ParticleAPI_v2.1.1<br>
+Zenchantments1.9-1.10<br>

--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,7 @@ port: '3306'
 db: 'seichiassist'
 id: 'root'
 pw: ''
+servernum: '1'
 defaultmineamount: '3'
 minutespeedamount: '0.01'
 onlineplayersamount: '0.5'
@@ -77,3 +78,4 @@ lv68message: "整地の際に獲得できる経験値量が増えました。"
 lv78message: "整地の際に獲得できる経験値量が増えました。"
 lv88message: "整地の際に獲得できる経験値量が増えました。"
 lv98message: "整地の際に獲得できる経験値量が増えました。"
+subhomemax: 3

--- a/src/com/github/unchama/seichiassist/Config.java
+++ b/src/com/github/unchama/seichiassist/Config.java
@@ -129,5 +129,14 @@ public class Config{
 		return config.getString("lv" + i + "message","");
 	}
 
+	//サーバー番号取得
+	public int getServerNum() {
+		return Util.toInt(config.getString("servernum"));
+	}
+	
+	//サブホーム最大数取得
+	public int getSubHomeMax() {
+		return Util.toInt(config.getString("subhomemax"));
+	}
 
 }

--- a/src/com/github/unchama/seichiassist/SeichiAssist.java
+++ b/src/com/github/unchama/seichiassist/SeichiAssist.java
@@ -63,7 +63,8 @@ public class SeichiAssist extends JavaPlugin{
 	public static Sql sql;
 	public static Config config;
 
-
+	public static final int SUB_HOME_DATASIZE = 98;	//DB上でのサブホーム1つ辺りのデータサイズ　xyz各10*3+ワールド名64+区切り文字1*4
+	
 	Random rand = new java.util.Random();
 	//起動するタスクリスト
 	private List<BukkitTask> tasklist = new ArrayList<BukkitTask>();

--- a/src/com/github/unchama/seichiassist/Sql.java
+++ b/src/com/github/unchama/seichiassist/Sql.java
@@ -284,6 +284,8 @@ public class Sql{
 				",add index if not exists name_index(name)" +
 				",add index if not exists uuid_index(uuid)" +
 				",add index if not exists ranking_index(totalbreaknum)" +
+				",add column if not exists homepoint_" + SeichiAssist.config.getServerNum() + " varchar(" + SeichiAssist.config.getSubHomeMax() * SeichiAssist.SUB_HOME_DATASIZE + ") default ''"+
+
 				"";
 		ActiveSkillEffect[] activeskilleffect = ActiveSkillEffect.values();
 		for(int i = 0; i < activeskilleffect.length ; i++){
@@ -488,7 +490,13 @@ public class Sql{
 	}
 
 
-
+	//サブホームを保存
+	public boolean UpDataSubHome(String s) {
+		String table = SeichiAssist.PLAYERDATA_TABLENAME;
+		String command = "update " + db + "." + table
+				+ " set homepoint_" + SeichiAssist.config.getServerNum() + " = '" + s + "'";
+		return putCommand(command);
+	}
 
 	public boolean loadPlayerData(final Player p) {
 		String name = Util.getName(p);

--- a/src/com/github/unchama/seichiassist/Sql.java
+++ b/src/com/github/unchama/seichiassist/Sql.java
@@ -491,13 +491,15 @@ public class Sql{
 
 
 	//サブホームを保存
+	/*
 	public boolean UpDataSubHome(String s) {
 		String table = SeichiAssist.PLAYERDATA_TABLENAME;
 		String command = "update " + db + "." + table
 				+ " set homepoint_" + SeichiAssist.config.getServerNum() + " = '" + s + "'";
 		return putCommand(command);
 	}
-
+*/
+	
 	public boolean loadPlayerData(final Player p) {
 		String name = Util.getName(p);
 		final UUID uuid = p.getUniqueId();

--- a/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -554,7 +555,49 @@ public class MenuInventoryData {
 		itemstack.setItemMeta(itemmeta);
 		inventory.setItem(4,itemstack);
 
+		//サブホーム関係
+		for(int x = 0 ; x < SeichiAssist.config.getSubHomeMax() ; x++){
+			//サブホームに移動ボタン
+			itemstack = new ItemStack(Material.COMPASS,1);
+			itemmeta = Bukkit.getItemFactory().getItemMeta(Material.COMPASS);
+			itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "サブホームポイント"+  (x+1) + "にワープ");
 
+			Location l = playerdata.GetSubHome(x);
+			if (l == null ){
+				lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.GRAY + "あらかじめ設定した"
+						, ChatColor.RESET + "" + ChatColor.GRAY + "サブホームポイント" + (x+1) + "にワープします"
+						, ChatColor.RESET + "" + ChatColor.DARK_GRAY + "うまく機能しない時は"
+						, ChatColor.RESET + "" + ChatColor.DARK_GRAY + "再接続してみてください"
+						, ChatColor.RESET + "" + ChatColor.DARK_RED + "" + ChatColor.UNDERLINE + "クリックでワープ"
+						, ChatColor.RESET + "" + ChatColor.GRAY + "未設定"
+						);
+			}else{
+				lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.GRAY + "あらかじめ設定した"
+						, ChatColor.RESET + "" + ChatColor.GRAY + "サブホームポイント" + (x+1) + "にワープします"
+						, ChatColor.RESET + "" + ChatColor.DARK_GRAY + "うまく機能しない時は"
+						, ChatColor.RESET + "" + ChatColor.DARK_GRAY + "再接続してみてください"
+						, ChatColor.RESET + "" + ChatColor.DARK_RED + "" + ChatColor.UNDERLINE + "クリックでワープ"
+						, ChatColor.RESET + "" + ChatColor.GRAY + "" + l.getWorld().getName() + " x:" + (int)l.getX() + " y:" + (int)l.getY() + " z:" + (int)l.getZ()
+						);
+			}
+			itemmeta.setLore(lore);
+			itemstack.setItemMeta(itemmeta);
+			inventory.setItem(29+x,itemstack);
+			
+			//サブホーム設定ボタン
+			itemstack = new ItemStack(Material.BED,1);
+			itemmeta = Bukkit.getItemFactory().getItemMeta(Material.BED);
+			itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "サブホームポイント" + (x+1) + "を設定");
+			lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.GRAY + "現在位置をサブホームポイント" + (x+1)
+					, ChatColor.RESET + "" + ChatColor.GRAY + "として設定します"
+					, ChatColor.RESET + "" + ChatColor.	DARK_GRAY + "※上書きされます"
+					, ChatColor.RESET + "" + ChatColor.DARK_RED + "" + ChatColor.UNDERLINE + "クリックで設定"
+					);
+			itemmeta.setLore(lore);
+			itemstack.setItemMeta(itemmeta);
+			inventory.setItem(20+x,itemstack);		
+			
+		}
 
 		return inventory;
 	}

--- a/src/com/github/unchama/seichiassist/data/PlayerData.java
+++ b/src/com/github/unchama/seichiassist/data/PlayerData.java
@@ -4,11 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.Statistic;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 
@@ -83,6 +85,9 @@ public class PlayerData {
 	//ガチャボタン連打防止用
 	public boolean gachacooldownflag;
 
+	//サブのホームポイント
+	private Location[] sub_home = new Location[SeichiAssist.config.getSubHomeMax()];
+
 	public PlayerData(Player player){
 		//初期値を設定
 		this.name = Util.getName(player);
@@ -118,6 +123,11 @@ public class PlayerData {
 		this.p_givenvote = 0;
 		this.votecooldownflag = true;
 		this.gachacooldownflag = true;
+		
+		for (int x = 0 ; x < SeichiAssist.config.getSubHomeMax() ; x++){
+//			this.sub_home[x] = new Location(null, 0, 0, 0);
+			this.sub_home[x] = null;
+		}
 
 	}
 
@@ -395,6 +405,75 @@ public class PlayerData {
 		}
 	}
 
+	
+	
+	//サブホームの位置をセットする
+	public void SetSubHome(Location l,int x){
+		if(x >= 0 & x < SeichiAssist.config.getSubHomeMax() ){
+			this.sub_home[x] = l;
+		}
+	}
 
+	//サブホームの位置を読み込む
+	public Location GetSubHome(int x){
+		if(x >= 0 & x < SeichiAssist.config.getSubHomeMax() ){
+			return this.sub_home[x];
+		}else{
+			return null;
+		}
+	}
+	
+	//文字列からサブデータを読み込む（DB用）
+	public void SetSubHome(String str){
+		String[] s = str.split(",", -1);
+		for( int x = 0 ; x < SeichiAssist.config.getSubHomeMax() ; x++){
+			if (s.length < x*4+3){
+				break;
+			}
+//			if(s[x*4] != "" && s[x*4+1] != "" && s[x*4+2] != "" && s[x*4+3] != ""){	//未設定項目を飛ばす　何故かうまく動かない
+			if(s[x*4].length() > 0 && s[x*4+1].length() > 0 && s[x*4+2].length() > 0 && s[x*4+3].length() > 0 ){
 
+				Location l = new Location( Bukkit.getWorld(s[x*4+3]) , Integer.parseInt(s[x*4]) , Integer.parseInt(s[x*4+1]) , Integer.parseInt(s[x*4+2]) );
+				this.sub_home[x] = l;
+			}
+		}
+	}
+
+	//文字列からサブデータを読み込む・デバッグ版（DB用）
+	public void SetSubHome(String str , Player player){
+		String[] s = str.split(",", -1);
+		player.sendMessage(str );
+		player.sendMessage("配列数" + s.length );
+		for( int x = 0 ; x < SeichiAssist.config.getSubHomeMax() ; x++){
+			if (s.length < x*4+3){
+				break;
+			}
+			player.sendMessage("x:" + s[x*4] + " y:" +s[x*4+1]+ " z:" +s[x*4+2]+ " w:"+s[x*4+3] );
+//			if(s[x*4] != "" && s[x*4+1] != "" && s[x*4+2] != "" && s[x*4+3] != ""){
+			if(s[x*4].length() > 0 && s[x*4+1].length() > 0 && s[x*4+2].length() > 0 && s[x*4+3].length() > 0 ){
+				player.sendMessage("読み込み");
+				Location l = new Location( Bukkit.getWorld(s[x*4+3]) , Integer.parseInt(s[x*4]) , Integer.parseInt(s[x*4+1]) , Integer.parseInt(s[x*4+2]) );
+				this.sub_home[x] = l;
+			}
+		}
+	}
+
+	//サブホームデータを文字列で返す（DB用）
+	public String SubHomeToString(){
+		String s = "";
+		for( int x = 0 ; x < SeichiAssist.config.getSubHomeMax() ; x++){
+			if (this.sub_home[x] == null){
+				//設定されてない場合
+				s += ",,,,";
+			}else{
+				//設定されてる場合
+				s += String.valueOf( (int)sub_home[x].getX() ) +",";
+				s += String.valueOf( (int)sub_home[x].getY() ) +",";
+				s += String.valueOf( (int)sub_home[x].getZ() ) +",";
+				s += sub_home[x].getWorld().getName() +",";
+			}
+		}
+		return s;
+	}
+	
 }

--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -9,8 +9,10 @@ import java.util.UUID;
 import net.md_5.bungee.api.ChatColor;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.World;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.HumanEntity;
@@ -410,14 +412,52 @@ public class PlayerInventoryListener implements Listener {
 			else if(itemstackcurrent.getType().equals(Material.BED)){
 				// sethomeコマンド実行
 				player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
-				player.chat("/sethome");
+				ItemMeta itemmeta = itemstackcurrent.getItemMeta();
+
+				if(itemmeta.getDisplayName().contains("サブホームポイント")){//ホームボタンかサブホームボタンか判定
+					//ホームをセット
+					int z = Integer.parseInt( itemmeta.getDisplayName().substring(15, 16) ) - 1;	//サブホームボタンの番号
+					playerdata.SetSubHome(player.getLocation(), z);
+					
+					//mysqlにも書き込んどく
+					if(!sql.UpDataSubHome(playerdata.SubHomeToString())){
+						player.sendMessage(ChatColor.RED + "失敗");
+					}else{
+						player.sendMessage("現在位置をサブホームポイント"+(z+1)+"に設定しました");
+					}					
+					player.closeInventory();
+				}else {
+					player.chat("/sethome");
+				}
 			}
 
 			else if(itemstackcurrent.getType().equals(Material.COMPASS)){
 				// homeコマンド実行
 				player.closeInventory();
 				player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
-				player.chat("/home");
+				
+				ItemMeta itemmeta = itemstackcurrent.getItemMeta();
+				if(itemmeta.getDisplayName().contains("サブホームポイント")){//ホームボタンかサブホームボタンか判定
+					//サブホームに移動
+					int z = Integer.parseInt( itemmeta.getDisplayName().substring(15, 16) ) - 1;	//サブホームボタンの番号
+					Location l = playerdata.GetSubHome(z);
+					if(l != null){
+						World world = Bukkit.getWorld(l.getWorld().getName());
+						if(world != null){
+							player.teleport(l);
+							player.sendMessage("サブホームポイント"+ (z+1) +"にワープしました");
+						}else{
+							player.sendMessage("サブホームポイント"+ (z+1) +"が設定されてません");
+						}
+					}else{
+						player.sendMessage("サブホームポイント"+ (z+1) +"が設定されてません");
+					}
+				}else {
+					player.chat("/home");
+				}
+				
+				
+				
 			}
 
 			else if(itemstackcurrent.getType().equals(Material.WOOD_AXE)){
@@ -570,6 +610,7 @@ public class PlayerInventoryListener implements Listener {
 				//インベントリを開く
 				player.openInventory(SeichiAssist.plugin.getServer().createInventory(null, 9*4 ,ChatColor.LIGHT_PURPLE + "" + ChatColor.BOLD + "交換したい景品を入れてください"));
 			}
+			
 		}
 	}
 	//スキルメニューの処理

--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -420,11 +420,14 @@ public class PlayerInventoryListener implements Listener {
 					playerdata.SetSubHome(player.getLocation(), z);
 					
 					//mysqlにも書き込んどく
+					/*別スレッド処理PlayerDataSaveTaskRunnableに移動
 					if(!sql.UpDataSubHome(playerdata.SubHomeToString())){
 						player.sendMessage(ChatColor.RED + "失敗");
 					}else{
 						player.sendMessage("現在位置をサブホームポイント"+(z+1)+"に設定しました");
-					}					
+					}
+					*/
+					player.sendMessage("現在位置をサブホームポイント"+(z+1)+"に設定しました");
 					player.closeInventory();
 				}else {
 					player.chat("/sethome");

--- a/src/com/github/unchama/seichiassist/task/LoadPlayerDataTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/LoadPlayerDataTaskRunnable.java
@@ -152,6 +152,9 @@ public class LoadPlayerDataTaskRunnable extends BukkitRunnable{
  				playerdata.activeskilldata.premiumeffectpoint = rs.getInt("premiumeffectpoint");
  				//マナの情報
  				playerdata.activeskilldata.mana.setMana(rs.getDouble("mana"));
+ 				
+ 				//subhomeの情報
+ 				playerdata.SetSubHome(rs.getString("homepoint_" + SeichiAssist.config.getServerNum()));
 
  				ActiveSkillEffect[] activeskilleffect = ActiveSkillEffect.values();
  				for(int i = 0 ; i < activeskilleffect.length ; i++){

--- a/src/com/github/unchama/seichiassist/task/PlayerDataSaveTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/PlayerDataSaveTaskRunnable.java
@@ -114,7 +114,10 @@ public class PlayerDataSaveTaskRunnable extends BukkitRunnable{
 				+ ",stack_coal = " + Integer.toString(playerdata.minestack.coal)
 				+ ",stack_coal_ore = " + Integer.toString(playerdata.minestack.coal_ore)
 				+ ",stack_iron_ore = " + Integer.toString(playerdata.minestack.iron_ore)
-				+ ",stack_packed_ice = " + Integer.toString(playerdata.minestack.packed_ice);
+				+ ",stack_packed_ice = " + Integer.toString(playerdata.minestack.packed_ice)
+				
+				//サブホームのデータ
+				+ ",homepoint_" + SeichiAssist.config.getServerNum() + " = '" + playerdata.SubHomeToString() + "'";
 
 
 		ActiveSkillEffect[] activeskilleffect = ActiveSkillEffect.values();


### PR DESCRIPTION
config.ymlのservernumでサーバーを識別、subhomemaxでサブホーム数を設定できます。
※DBのサイズ変更が未対応のため一度設定したsubhomemax値を変更するのは危険です。

コマンドは未実装です。

追加修正：サブホームデータをMySQLに保存する処理をPlayerDataSaveTaskRunnableに移動。