### PR TITLE
実績メニューの不具合修正

### DIFF
--- a/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -3105,7 +3105,7 @@ public class MenuInventoryData {
 			inventory.setItem(5,itemstack);
 		}
 		//500位
-		if(playerdata.TitleFlags.get(1006)){
+		if(playerdata.TitleFlags.get(1007)){
 			itemstack = new ItemStack(Material.DIAMOND_BLOCK,1);
 			itemmeta = Bukkit.getItemFactory().getItemMeta(Material.DIAMOND_BLOCK);
 			itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "No1007「"+ SeichiAssist.config.getTitle(1007) +"」" );

--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -2192,9 +2192,15 @@ public class PlayerInventoryListener implements Listener {
     		//表示内容をLVと二つ名で切り替えるための処理
 			if(itemstackcurrent.getType().equals(Material.REDSTONE_TORCH_ON)){
 				if(playerdata.displayTypeLv){
-					playerdata.displayTypeLv = false;
-					player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
-					player.openInventory(MenuInventoryData.getTitleMenuData(player));
+					if(!(playerdata.displayTitleNo == 0)){
+						playerdata.displayTypeLv = false ;
+						player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
+						player.openInventory(MenuInventoryData.getTitleMenuData(player));
+					}else {
+						player.sendMessage("先に利用したい「二つ名」を選択してください。");
+						player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
+						player.openInventory(MenuInventoryData.getTitleMenuData(player));
+					}
 				}else{
 					playerdata.displayTypeLv = true ;
 					player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);

--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -2325,7 +2325,7 @@ public class PlayerInventoryListener implements Listener {
     			ItemMeta itemmeta = itemstackcurrent.getItemMeta();
     			player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
     			player.sendMessage("この実績は自動解禁式です。毎分の処理をお待ちください。");
-    			player.openInventory(MenuInventoryData.getTitleRankData(player));
+    			player.openInventory(MenuInventoryData.getTitleAmountData(player));
     		}
     		else if (itemstackcurrent.getType().equals(Material.DIAMOND_BLOCK)){
     			ItemMeta itemmeta = itemstackcurrent.getItemMeta();
@@ -2374,7 +2374,7 @@ public class PlayerInventoryListener implements Listener {
     				playerdata.displayTitleNo = 3011 ;
     				player.sendMessage("二つ名「"+ SeichiAssist.config.getTitle(3011) +"」が設定されました。");
     			}
-    			player.openInventory(MenuInventoryData.getTitleRankData(player));
+    			player.openInventory(MenuInventoryData.getTitleAmountData(player));
 
     		}
     		//実績メニューに戻る


### PR DESCRIPTION
・整地量メニューから整地神メニューに移動しちゃう不具合
・整地神500位の実績が250位の実績を解除しないと手に入らない不具合

を修正。

・二つ名・LV切り替えのボタンに「二つ名未設定時」の挙動を追加
