### PR TITLE
深刻な不具合を修正

### DIFF
--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -1858,10 +1858,42 @@ public class PlayerInventoryListener implements Listener {
 							&& itemstackcurrent.getDurability() == SeichiAssist.minestacklist.get(i).getDurability()){ //MaterialとサブIDが一致
 
 						if(SeichiAssist.minestacklist.get(i).getNameloreflag()==false){
-							playerdata.minestack.setNum(i, (giveMineStack(player,playerdata.minestack.getNum(i),new ItemStack(SeichiAssist.minestacklist.get(i).getMaterial(), 1, (short)SeichiAssist.minestacklist.get(i).getDurability() ))) );
-							open_flag = (Util.getMineStackTypeindex(i)+1)/45;
-							open_flag_type=SeichiAssist.minestacklist.get(i).getStacktype();
-						} else { //名前と説明文がある
+
+							//同じ名前の別アイテムに対応するためにインベントリの「解放レベル」を見る
+							int level = SeichiAssist.config.getMineStacklevel(SeichiAssist.minestacklist.get(i).getLevel());
+							int level_ = 0;
+							String temp = null;
+							for(int j=0; j<itemstackcurrent.getItemMeta().getLore().size(); j++){
+								String lore = itemstackcurrent.getItemMeta().getLore().get(j);
+								//System.out.println(j);
+						        Pattern p = Pattern.compile(".*Lv[0-9]+以上でスタック可能.*");
+						        Matcher m = p.matcher(lore);
+						        if(m.matches()){
+						        	//System.out.println(lore);
+						        	String matchstr = lore.replaceAll("^.*Lv","");
+						        	//System.out.println(matchstr);
+						        	level_ = Integer.parseInt(matchstr.replaceAll("[^0-9]+","")); //数字以外を全て消す
+						        	break;
+						        }
+							}
+							//System.out.println(level + " " + level_);
+
+							if(level==level_){
+								//System.out.println("AAA");
+
+								String itemstack_name = itemstackcurrent.getItemMeta().getDisplayName();
+								String minestack_name = SeichiAssist.minestacklist.get(i).getJapaneseName();
+								itemstack_name = itemstack_name.replaceAll("§[0-9A-Za-z]","");
+								minestack_name = minestack_name.replaceAll("§[0-9A-Za-z]","");
+								if(itemstack_name.equals(minestack_name)){ //表記はアイテム名だけなのでアイテム名で判定
+									//System.out.println("BBB");
+
+									playerdata.minestack.setNum(i, (giveMineStack(player,playerdata.minestack.getNum(i),new ItemStack(SeichiAssist.minestacklist.get(i).getMaterial(), 1, (short)SeichiAssist.minestacklist.get(i).getDurability() ))) );
+									open_flag = (Util.getMineStackTypeindex(i)+1)/45;
+									open_flag_type=SeichiAssist.minestacklist.get(i).getStacktype();
+								}
+							}
+						} else if(SeichiAssist.minestacklist.get(i).getNameloreflag()==true && itemstackcurrent.getItemMeta().hasDisplayName()){ //名前と説明文がある
 							//System.out.println("debug AA");
 							//同じ名前の別アイテムに対応するためにインベントリの「解放レベル」を見る
 							int level = SeichiAssist.config.getMineStacklevel(SeichiAssist.minestacklist.get(i).getLevel());

--- a/src/com/github/unchama/seichiassist/listener/PlayerPickupItemListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerPickupItemListener.java
@@ -122,7 +122,7 @@ public class PlayerPickupItemListener implements Listener {
 			if(material.equals(SeichiAssist.minestacklist.get(i).getMaterial()) &&
 				itemstack.getDurability() == SeichiAssist.minestacklist.get(i).getDurability()){
 				//この時点でIDとサブIDが一致している
-				if(SeichiAssist.minestacklist.get(i).getNameloreflag()==false){//名前と説明文が無いアイテム
+				if(SeichiAssist.minestacklist.get(i).getNameloreflag()==false && (!itemstack.getItemMeta().hasLore() && !itemstack.getItemMeta().hasDisplayName() ) ){//名前と説明文が無いアイテム
 					if(playerdata.level < config.getMineStacklevel(SeichiAssist.minestacklist.get(i).getLevel())){
 						//レベルを満たしていない
 						return;
@@ -130,12 +130,14 @@ public class PlayerPickupItemListener implements Listener {
 						playerdata.minestack.addNum(i, amount);
 						break;
 					}
-				} else {
+				} else if(SeichiAssist.minestacklist.get(i).getNameloreflag()==true && itemstack.getItemMeta().hasDisplayName() && itemstack.getItemMeta().hasLore()){
 					//名前・説明文付き
 					ItemMeta meta = itemstack.getItemMeta();
+					/*
 					if(meta==null || meta.getDisplayName()==null || meta.getLore()== null){
 						return;
 					}
+					*/
 					//この時点で名前と説明文がある
 						if(SeichiAssist.minestacklist.get(i).getGachatype()==-1){ //ガチャ以外のアイテム(がちゃりんご)
 							if( !(meta.getDisplayName().equals(Util.getGachaimoName()))

--- a/src/com/github/unchama/seichiassist/util/BreakUtil.java
+++ b/src/com/github/unchama/seichiassist/util/BreakUtil.java
@@ -191,7 +191,7 @@ public class BreakUtil {
 			if(material.equals(SeichiAssist.minestacklist.get(i).getMaterial()) &&
 				itemstack.getDurability() == SeichiAssist.minestacklist.get(i).getDurability()){
 				//この時点でIDとサブIDが一致している
-				if(SeichiAssist.minestacklist.get(i).getNameloreflag()==false){//名前と説明文が無いアイテム
+				if(SeichiAssist.minestacklist.get(i).getNameloreflag()==false && (!itemstack.getItemMeta().hasLore() && !itemstack.getItemMeta().hasDisplayName() ) ){//名前と説明文が無いアイテム
 					if(playerdata.level < config.getMineStacklevel(SeichiAssist.minestacklist.get(i).getLevel())){
 						//レベルを満たしていない
 						return false;
@@ -200,21 +200,27 @@ public class BreakUtil {
 						//delete_flag=true;
 						break;
 					}
-				} else {
+				} else if(SeichiAssist.minestacklist.get(i).getNameloreflag()==true && itemstack.getItemMeta().hasDisplayName() && itemstack.getItemMeta().hasLore()){
 					//名前・説明文付き
 					ItemMeta meta = itemstack.getItemMeta();
+					/*
 					if(meta==null || meta.getDisplayName()==null || meta.getLore()== null){
-						return false;
+						return;
 					}
+					*/
 					//この時点で名前と説明文がある
 						if(SeichiAssist.minestacklist.get(i).getGachatype()==-1){ //ガチャ以外のアイテム(がちゃりんご)
 							if( !(meta.getDisplayName().equals(Util.getGachaimoName()))
 								|| !(meta.getLore().equals(Util.getGachaimoLore())) ){
 								return false;
 							}
-							playerdata.minestack.addNum(i, amount);
-							//delete_flag=true;
-							break;
+							if(playerdata.level < config.getMineStacklevel(SeichiAssist.minestacklist.get(i).getLevel())){
+								//レベルを満たしていない
+								return false;
+							} else {
+								playerdata.minestack.addNum(i, amount);
+								break;
+							}
 						} else {
 							//ガチャ品
 							MineStackGachaData g = SeichiAssist.msgachadatalist.get(SeichiAssist.minestacklist.get(i).getGachatype());


### PR DESCRIPTION
MineStackの「ホームランバット」を普通の「ブレイズロッド」と認識する不具合の修正
・格納時にホームランバットがブレイズロッドに入ってしまう問題
・取り出し時にホームランバットとブレイズロッドの両方が取り出される問題
