### PR TITLE
EXP瓶一括使用／消音機能／初見アイテム

### DIFF
--- a/src/com/github/unchama/seichiassist/Sql.java
+++ b/src/com/github/unchama/seichiassist/Sql.java
@@ -685,6 +685,11 @@ public class Sql{
  			plugin.getServer().getConsoleSender().sendMessage(ChatColor.YELLOW + "【初見キタ】" + p.getName() + "のプレイヤーデータ作成完了");
  			Util.sendEveryMessage(ChatColor.LIGHT_PURPLE+""+ChatColor.BOLD+name+"さんは初参加です。整地鯖へヨウコソ！" + ChatColor.RESET +" - " + ChatColor.YELLOW + ChatColor.UNDERLINE +  "http://seichi.click");
  			Util.sendEverySound(Sound.ENTITY_PLAYER_LEVELUP, 1, 1);
+ 			//初見プレイヤーに木の棒、エリトラ、ピッケルを配布
+ 			p.getInventory().addItem(new ItemStack(Material.STICK));
+ 			p.getInventory().addItem(new ItemStack(Material.ELYTRA));
+ 			p.getInventory().addItem(new ItemStack(Material.DIAMOND_PICKAXE));
+ 			p.getInventory().addItem(new ItemStack(Material.DIAMOND_SPADE));
  			return true;
 
  		}else if(count == 1){

--- a/src/com/github/unchama/seichiassist/Sql.java
+++ b/src/com/github/unchama/seichiassist/Sql.java
@@ -396,6 +396,7 @@ public class Sql{
 				",add column if not exists totalexp int default 0" +
 				",add column if not exists expmarge tinyint unsigned default 0" +
 				",add column if not exists shareinv blob" +
+				",add column if not exists everysound boolean default false" +
 
 				",add index if not exists name_index(name)" +
 				",add index if not exists uuid_index(uuid)" +

--- a/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -586,6 +586,13 @@ public class MenuInventoryData {
 		itemstack.setItemMeta(skullmeta);
 		inventory.setItem(12,itemstack);
 
+		//全体通知音消音のトグルボタン
+		itemstack = new ItemStack(Material.JUKEBOX,1);
+		itemmeta = Bukkit.getItemFactory().getItemMeta(Material.JUKEBOX);
+		itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "全体通知音消音切替");
+		itemstack.setItemMeta(dispWinSoundToggleMeta(playerdata,itemmeta));
+		inventory.setItem(13,itemstack);
+
 		//死亡メッセージ表示のトグルボタン
 		itemstack = new ItemStack(Material.FLINT_AND_STEEL,1);
 		itemmeta = Bukkit.getItemFactory().getItemMeta(Material.FLINT_AND_STEEL);
@@ -2452,6 +2459,21 @@ public class MenuInventoryData {
 		itemstack.setItemMeta(itemmeta);
 		inv.setItem(set,itemstack);
 		return inv;
+	}
+	// 全体通知音消音トグルボタン
+	public static ItemMeta dispWinSoundToggleMeta(PlayerData playerdata,ItemMeta itemmeta){
+		List<String> lore = new ArrayList<String>();
+		if(playerdata.everysoundflag){
+			itemmeta.addEnchant(Enchantment.DIG_SPEED, 100, false);
+			lore.add(ChatColor.RESET + "" +  ChatColor.GREEN + "消音する");
+			lore.add(ChatColor.RESET + "" +  ChatColor.DARK_RED + "" + ChatColor.UNDERLINE + "クリックで解除");
+		}else{
+			itemmeta.removeEnchant(Enchantment.DIG_SPEED);
+			lore.add(ChatColor.RESET + "" +  ChatColor.RED + "消音しない");
+			lore.add(ChatColor.RESET + "" +  ChatColor.DARK_GREEN + "" + ChatColor.UNDERLINE + "クリックで設定");
+		}
+		itemmeta.setLore(lore);
+		return itemmeta;
 	}
 	// 死亡メッセージ表示トグルボタン
 	public static ItemMeta dispKillLogToggleMeta(PlayerData playerdata,ItemMeta itemmeta){

--- a/src/com/github/unchama/seichiassist/data/PlayerData.java
+++ b/src/com/github/unchama/seichiassist/data/PlayerData.java
@@ -67,7 +67,8 @@ public class PlayerData {
 	public int playtick;
 	//キルログ表示トグル
 	public boolean dispkilllogflag;
-
+	//全体通知音消音トグル
+	public boolean everysoundflag;
 	//ワールドガード保護ログ表示トグル
 	public boolean dispworldguardlogflag;
 	//複数種類破壊トグル

--- a/src/com/github/unchama/seichiassist/listener/PlayerClickListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerClickListener.java
@@ -12,6 +12,7 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.ThrownExpBottle;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -548,6 +549,20 @@ public class PlayerClickListener implements Listener {
 					//インベントリを開く
 					player.openInventory(playerdata.inventory);
 			}
+		}
+	}
+
+	//　経験値瓶を持った状態でのShift右クリック…一括使用
+	@EventHandler
+	public void onPlayerRightClickExpBottleEvent(PlayerInteractEvent event){
+		// 経験値瓶を持った状態でShift右クリックをした場合
+		if (event.getPlayer().isSneaking() && event.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.EXP_BOTTLE)
+				&& (event.getAction().equals(Action.RIGHT_CLICK_AIR) || event.getAction().equals(Action.RIGHT_CLICK_BLOCK))) {
+			int num = event.getItem().getAmount();
+			for(int cnt = 0; cnt < num; cnt++) {
+				event.getPlayer().launchProjectile(ThrownExpBottle.class);
+			}
+			event.getPlayer().getInventory().setItemInMainHand(new ItemStack(Material.AIR));
 		}
 	}
 

--- a/src/com/github/unchama/seichiassist/listener/PlayerClickListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerClickListener.java
@@ -285,7 +285,10 @@ public class PlayerClickListener implements Listener {
 
 				//確率に応じてメッセージを送信
 				if(present.probability < 0.001){
-					Util.sendEverySound(Sound.ENTITY_ENDERDRAGON_DEATH,(float)0.5, 2);
+					Util.sendEverySoundWithoutIgnore(Sound.ENTITY_ENDERDRAGON_DEATH,(float)0.5, 2);
+					if (playerdata.everysoundflag) {
+						player.playSound(player.getLocation(), Sound.ENTITY_ENDERDRAGON_DEATH, (float) 0.5, 2);
+					}
 					player.sendMessage(ChatColor.RED + "おめでとう！！！！！Gigantic☆大当たり！" + str);
 					Util.sendEveryMessage(ChatColor.GOLD + player.getDisplayName() + "がガチャでGigantic☆大当たり！\n" + ChatColor.AQUA + present.itemstack.getItemMeta().getDisplayName() + ChatColor.GOLD + "を引きました！おめでとうございます！");
 				}else if(present.probability < 0.01){

--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -420,6 +420,20 @@ public class PlayerInventoryListener implements Listener {
 				itemstackcurrent.setItemMeta(MenuInventoryData.dispKillLogToggleMeta(playerdata,itemmeta));
 			}
 
+			else if(itemstackcurrent.getType().equals(Material.JUKEBOX)){
+				// 全体通知音消音トグル
+				playerdata.everysoundflag = !playerdata.everysoundflag;
+				if(playerdata.everysoundflag){
+					player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
+					player.sendMessage(ChatColor.GREEN + "消音可能な全体通知音を消音します");
+				}else{
+					player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, (float)0.5);
+					player.sendMessage(ChatColor.RED + "消音設定を解除しました");
+				}
+				ItemMeta itemmeta = itemstackcurrent.getItemMeta();
+				itemstackcurrent.setItemMeta(MenuInventoryData.dispWinSoundToggleMeta(playerdata,itemmeta));
+			}
+
 			//追加
 			else if(itemstackcurrent.getType().equals(Material.BARRIER)){
 				// ワールドガード保護表示トグル

--- a/src/com/github/unchama/seichiassist/task/LoadPlayerDataTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/LoadPlayerDataTaskRunnable.java
@@ -162,6 +162,7 @@ public class LoadPlayerDataTaskRunnable extends BukkitRunnable{
  				playerdata.totalexp = rs.getInt("totalexp");
  				playerdata.expmarge = rs.getByte("expmarge");
  				playerdata.shareinv = (rs.getString("shareinv") != "" && rs.getString("shareinv") != null);
+ 				playerdata.everysoundflag = rs.getBoolean("everysound");
 
  				//subhomeの情報
  				playerdata.SetSubHome(rs.getString("homepoint_" + SeichiAssist.config.getServerNum()));

--- a/src/com/github/unchama/seichiassist/task/PlayerDataSaveTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/PlayerDataSaveTaskRunnable.java
@@ -104,6 +104,7 @@ public class PlayerDataSaveTaskRunnable extends BukkitRunnable{
 				+ ",expvisible = " + Boolean.toString(playerdata.expbar.isVisible())
 				+ ",totalexp = " + Integer.toString(playerdata.totalexp)
 				+ ",expmarge = " + Byte.toString(playerdata.expmarge)
+				+ ",everysound = " + Boolean.toString(playerdata.everysoundflag)
 
 				+",displayTypeLv = " + Boolean.toString(playerdata.displayTypeLv)
 				+",displayTitleNo = " + Integer.toString(playerdata.displayTitleNo);

--- a/src/com/github/unchama/seichiassist/util/Util.java
+++ b/src/com/github/unchama/seichiassist/util/Util.java
@@ -6,9 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-import net.coreprotect.CoreProtect;
-import net.coreprotect.CoreProtectAPI;
-
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -26,11 +23,13 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.plugin.Plugin;
 
-import zedly.zenchantments.Zenchantments;
-
 import com.github.unchama.seichiassist.SeichiAssist;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+
+import net.coreprotect.CoreProtect;
+import net.coreprotect.CoreProtectAPI;
+import zedly.zenchantments.Zenchantments;
 
 public class Util {
 	static private FireworkEffect.Type[] types = { FireworkEffect.Type.BALL,
@@ -195,6 +194,14 @@ public class Util {
 		SeichiAssist plugin = SeichiAssist.plugin;
 		for ( Player player : plugin.getServer().getOnlinePlayers() ) {
 			player.playSound(player.getLocation(), str, a, b);
+		}
+	}
+	public static void sendEverySoundWithoutIgnore(Sound str, float a, float b){
+		SeichiAssist plugin = SeichiAssist.plugin;
+		for ( Player player : plugin.getServer().getOnlinePlayers() ) {
+			if (!SeichiAssist.playermap.get(player.getUniqueId()).everysoundflag) {
+				player.playSound(player.getLocation(), str, a, b);
+			}
 		}
 	}
 


### PR DESCRIPTION
・EXP瓶一括使用機能の追加
EXP瓶をメインハンドに持った状態でShift右クリックで一括使用可能。
[無効化方法]onPlayerRightClickExpBottleEventのコメントアウト

・消音可能な全体通知音消音トグル追加（アイデアノート39番）
3種の全体メッセージ（お初、当選、アサルト）のうち、当選のみを対象としている
チャットログは全体送信のまま、自当選の音だけは聞こえる
[無効化方法]MenuInventoryData#594 inventory.setItem(13,itemstack); のコメントアウト

・初見プレイヤー配布アイテムの追加（アイデアノートtodo）
ひとまずデフォルトの棒・エリトラ・ピッケル・シャベルを配布
[無効化方法]Sql.java #690 - #693 loadPlayerDataのコメントアウト