### PR TITLE
コマンド追加、ランキング修正、BungeeCord連携のI/Fのみ仮導入

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -38,3 +38,8 @@ commands:
       usage: /<command>
       permission: multiseichiplugin.stick
       permission-message: You don't have <permission>
+  shareinv:
+      description: This is a share inventory command.
+      usage: /<command>
+      default-permission: NOT_OP
+      permission-message: You don't have <permission>

--- a/src/com/github/unchama/seichiassist/SeichiAssist.java
+++ b/src/com/github/unchama/seichiassist/SeichiAssist.java
@@ -10,6 +10,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -21,12 +22,14 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 
+import com.github.unchama.seichiassist.bungee.BungeeReceiver;
 import com.github.unchama.seichiassist.commands.effectCommand;
 import com.github.unchama.seichiassist.commands.gachaCommand;
 import com.github.unchama.seichiassist.commands.lastquitCommand;
 import com.github.unchama.seichiassist.commands.levelCommand;
 import com.github.unchama.seichiassist.commands.rmpCommand;
 import com.github.unchama.seichiassist.commands.seichiCommand;
+import com.github.unchama.seichiassist.commands.shareinvCommand;
 import com.github.unchama.seichiassist.commands.stickCommand;
 import com.github.unchama.seichiassist.data.GachaData;
 import com.github.unchama.seichiassist.data.MineStackGachaData;
@@ -595,6 +598,7 @@ public class SeichiAssist extends JavaPlugin{
 		commandlist.put("lastquit",new lastquitCommand(plugin));
 		commandlist.put("stick",new stickCommand(plugin));
 		commandlist.put("rmp",new rmpCommand(plugin));
+		commandlist.put("shareinv",new shareinvCommand(plugin));
 
 		//リスナーの登録
 		getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);
@@ -606,6 +610,10 @@ public class SeichiAssist extends JavaPlugin{
 		getServer().getPluginManager().registerEvents(new PlayerPickupItemListener(), this);
 		getServer().getPluginManager().registerEvents(new PlayerDeathEventListener(), this);
 		getServer().getPluginManager().registerEvents(new GachaItemListener(), this);
+		// BungeeCordとのI/F
+		Bukkit.getMessenger().registerIncomingPluginChannel(this, "SeichiAssistBungee", new BungeeReceiver(this));
+		Bukkit.getMessenger().registerOutgoingPluginChannel(this, "SeichiAssistBungee");
+
 
 		//オンラインの全てのプレイヤーを処理
 		for(Player p : getServer().getOnlinePlayers()){

--- a/src/com/github/unchama/seichiassist/bungee/BungeeReceiver.java
+++ b/src/com/github/unchama/seichiassist/bungee/BungeeReceiver.java
@@ -1,0 +1,71 @@
+package com.github.unchama.seichiassist.bungee;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+
+import com.github.unchama.seichiassist.SeichiAssist;
+import com.github.unchama.seichiassist.data.PlayerData;
+
+public class BungeeReceiver implements PluginMessageListener {
+	private SeichiAssist plugin;
+
+	public BungeeReceiver(SeichiAssist plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public synchronized void onPluginMessageReceived(String channel, Player player, byte[] message) {
+		// ストリームの準備
+		ByteArrayInputStream stream = new ByteArrayInputStream(message);
+		DataInputStream in = new DataInputStream(stream);
+		try {
+			String subchannel = in.readUTF();
+			switch (subchannel) {
+			// サウンド再生要求の場合
+			case "PlaySound":
+				// データ内容はUUIDが登録されている
+				String uuid = in.readUTF();
+				// 受信UUIDからプレイヤーを特定
+				Player p = plugin.getServer().getPlayer(UUID.fromString(uuid));
+				// プレイヤーに対しレベルアップ音を再生する
+				p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1, 1);
+				break;
+			case "GetLocation":
+				getLocation(in.readUTF(), in.readUTF(), in.readUTF());
+				break;
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void getLocation(String servername, String uuid, String wanter) {
+		// 受信UUIDからプレイヤーを特定
+		Player p = plugin.getServer().getPlayer(UUID.fromString(uuid));
+		// プレイヤーデータを取得
+		PlayerData pd = SeichiAssist.playermap.get(UUID.fromString(uuid));
+
+		ByteArrayOutputStream b = new ByteArrayOutputStream();
+		DataOutputStream out = new DataOutputStream(b);
+		try {
+			// 返却データの生成
+			out.writeUTF("GetLocation");
+			out.writeUTF(wanter);
+			// プレイヤーの座標を返却
+			out.writeUTF(p.getName() + ": 整地Lv" + Integer.toString(pd.level) + " (総整地量: " + String.format("%,d", pd.totalbreaknum) + ")");
+			out.writeUTF("Server: " + servername + ", " + "World: " + p.getWorld().getName() + " (" + Integer.toString(p.getLocation().getBlockX()) + ", " + Integer.toString(p.getLocation().getBlockY()) +", " + Integer.toString(p.getLocation().getBlockZ()) + ")");
+			p.sendMessage(wanter + "からプレイヤーデータの要求があったため、データを送信しました。");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		p.sendPluginMessage(plugin, "SeichiAssistBungee", b.toByteArray());
+	}
+}

--- a/src/com/github/unchama/seichiassist/commands/shareinvCommand.java
+++ b/src/com/github/unchama/seichiassist/commands/shareinvCommand.java
@@ -1,0 +1,140 @@
+package com.github.unchama.seichiassist.commands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+import com.github.unchama.seichiassist.SeichiAssist;
+import com.github.unchama.seichiassist.Sql;
+import com.github.unchama.seichiassist.data.PlayerData;
+import com.github.unchama.seichiassist.util.SerializeItemList;
+import com.github.unchama.seichiassist.util.Util;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class shareinvCommand implements TabExecutor {
+	public shareinvCommand(SeichiAssist plugin) {
+	}
+
+	@Override
+	public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+		return null;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		if (!(sender instanceof Player)) {
+			// プレイヤーからの送信でない時処理終了
+			sender.sendMessage(ChatColor.GREEN + "このコマンドはゲーム内から実行してください");
+			return true;
+		}
+		shareInv((Player) sender);
+		return true;
+	}
+
+	public void shareInv(Player player) {
+		PlayerData playerdata = SeichiAssist.playermap.get(player.getUniqueId());
+		Sql sql = SeichiAssist.plugin.sql;
+
+		ItemStack air = new ItemStack(Material.AIR);
+		// 収納中なら取り出す
+		if (playerdata.shareinv) {
+			String serial = sql.loadShareInv(player, playerdata);
+			if (serial == "") {
+				player.sendMessage(ChatColor.RESET + "" + ChatColor.RED + "" + ChatColor.BOLD + "収納アイテムが存在しません。");
+			} else if (serial != null) {
+				PlayerInventory pi = player.getInventory();
+				List<ItemStack> items = SerializeItemList.fromBase64(serial);
+
+				// 取得完了見込みにより現所持アイテムをドロップ＆クリア
+				ItemStack offhand = pi.getItemInOffHand();
+				if (offhand != null && !offhand.getType().equals(Material.AIR)) {
+					Util.dropItem(player, offhand);
+				}
+				pi.setItemInOffHand(air);
+
+				ItemStack[] armor = pi.getArmorContents();
+				for (int cnt = 0; cnt < armor.length; cnt++) {
+					if (armor[cnt] != null && !armor[cnt].getType().equals(Material.AIR)) {
+						Util.dropItem(player, armor[cnt]);
+					}
+					armor[cnt] = air;
+				}
+				pi.setArmorContents(armor);
+
+				ItemStack[] contents = pi.getStorageContents();
+				for (int cnt = 0; cnt < contents.length; cnt++) {
+					if (contents[cnt] != null && !contents[cnt].getType().equals(Material.AIR)) {
+						Util.dropItem(player, contents[cnt]);
+					}
+					contents[cnt] = air;
+				}
+				pi.setStorageContents(contents);
+
+				// 収納アイテムを分割
+				offhand = items.get(0);
+				armor = items.subList(1, 5).toArray(new ItemStack[0]);
+				contents = items.subList(5, items.size()).toArray(new ItemStack[0]);
+
+				// アイテムを取り出し
+				pi.setItemInOffHand(offhand);
+				pi.setArmorContents(armor);
+				pi.setStorageContents(contents);
+				// SQLデータをクリア
+				sql.clearShareInv(player, playerdata);
+				playerdata.shareinv = false;
+				player.sendMessage(ChatColor.GREEN + "アイテムを取得しました。手持ちにあったアイテムはドロップしました。");
+				Bukkit.getLogger().info(Util.getName(player) + "がアイテム取り出しを実施(SQL送信成功)");
+			}
+		}
+		// 収納処理
+		else {
+			PlayerInventory pi = player.getInventory();
+			List<ItemStack> items = new ArrayList<ItemStack>();
+
+			// アイテム一覧をリストに取り出す
+			ItemStack offhand = pi.getItemInOffHand();
+			items.add(offhand);
+			ItemStack[] armor = pi.getArmorContents();
+			items.addAll(Arrays.asList(armor));
+			ItemStack[] contents = pi.getStorageContents();
+			items.addAll(Arrays.asList(contents));
+
+			// アイテム一覧をシリアル化する
+			String serial = SerializeItemList.toBase64(items);
+			if (serial == "") {
+				// 収納失敗
+				player.sendMessage(ChatColor.RESET + "" + ChatColor.RED + "" + ChatColor.BOLD + "収納アイテムの変換に失敗しました。");
+			} else {
+				if (sql.saveShareInv(player, playerdata, serial)) {
+					// 収納成功により現所持アイテムを全て削除
+					pi.setItemInOffHand(air);
+					for (int cnt = 0; cnt < armor.length; cnt++) {
+						armor[cnt] = air;
+					}
+					pi.setArmorContents(armor);
+					for (int cnt = 0; cnt < contents.length; cnt++) {
+						contents[cnt] = air;
+					}
+					pi.setStorageContents(contents);
+
+					// インベントリ共有ボタンをトグル
+					playerdata.shareinv = true;
+					player.sendMessage(ChatColor.GREEN + "アイテムを収納しました。10秒以上あとに、手持ちを空にして取り出してください。");
+					Bukkit.getLogger().info(Util.getName(player) + "がアイテム収納を実施(SQL送信成功)");
+					// 木の棒を取得
+					player.chat("/stick");
+				}
+			}
+		}
+	}
+}

--- a/src/com/github/unchama/seichiassist/data/PlayerData.java
+++ b/src/com/github/unchama/seichiassist/data/PlayerData.java
@@ -22,6 +22,8 @@ import com.github.unchama.seichiassist.util.Util;
 
 
 public class PlayerData {
+	//読み込み済みフラグ
+	public boolean loaded = false;
 	//プレイヤー名
 	public String name;
 	//UUID
@@ -128,6 +130,7 @@ public class PlayerData {
 
 	public PlayerData(Player player){
 		//初期値を設定
+		this.loaded = false;
 		this.name = Util.getName(player);
 		this.uuid = player.getUniqueId();
 		this.effectflag = true;

--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -8,8 +8,6 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.md_5.bungee.api.ChatColor;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -29,7 +27,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -52,9 +49,10 @@ import com.github.unchama.seichiassist.data.PlayerData;
 import com.github.unchama.seichiassist.task.CoolDownTaskRunnable;
 import com.github.unchama.seichiassist.task.TitleUnlockTaskRunnable;
 import com.github.unchama.seichiassist.util.ExperienceManager;
-import com.github.unchama.seichiassist.util.SerializeItemList;
 import com.github.unchama.seichiassist.util.Util;
 import com.sk89q.worldedit.bukkit.selections.Selection;
+
+import net.md_5.bungee.api.ChatColor;
 
 public class PlayerInventoryListener implements Listener {
 	HashMap<UUID,PlayerData> playermap = SeichiAssist.playermap;
@@ -740,97 +738,8 @@ public class PlayerInventoryListener implements Listener {
 			// インベントリ共有ボタン
 			else if(itemstackcurrent.getType().equals(Material.TRAPPED_CHEST)&&
 					itemstackcurrent.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "インベントリ共有")){
-				ItemStack air = new ItemStack(Material.AIR);
-				// 収納中なら取り出す
-				if (playerdata.shareinv) {
-					String serial = sql.loadShareInv(player, playerdata);
-					if (serial == "") {
-						player.sendMessage(ChatColor.RESET + "" +  ChatColor.RED + "" + ChatColor.BOLD + "収納アイテムが存在しません。");
-					} else if (serial != null) {
-						PlayerInventory pi = player.getInventory();
-						List<ItemStack> items = SerializeItemList.fromBase64(serial);
-
-						// 取得完了見込みにより現所持アイテムをドロップ＆クリア
-						ItemStack offhand = pi.getItemInOffHand();
-						if (offhand != null && !offhand.getType().equals(Material.AIR)) {
-							Util.dropItem(player, offhand);
-						}
-						pi.setItemInOffHand(air);
-
-						ItemStack[] armor = pi.getArmorContents();
-						for (int cnt = 0; cnt < armor.length; cnt++) {
-							if (armor[cnt] != null && !armor[cnt].getType().equals(Material.AIR)) {
-								Util.dropItem(player, armor[cnt]);
-							}
-							armor[cnt] = air;
-						}
-						pi.setArmorContents(armor);
-
-						ItemStack[] contents = pi.getStorageContents();
-						for (int cnt = 0; cnt < contents.length; cnt++) {
-							if (contents[cnt] != null && !contents[cnt].getType().equals(Material.AIR)) {
-								Util.dropItem(player, contents[cnt]);
-							}
-							contents[cnt] = air;
-						}
-						pi.setStorageContents(contents);
-
-						// 収納アイテムを分割
-						offhand = items.get(0);
-						armor = items.subList(1, 5).toArray(new ItemStack[0]);
-						contents = items.subList(5, items.size()).toArray(new ItemStack[0]);
-
-						// アイテムを取り出し
-						pi.setItemInOffHand(offhand);
-						pi.setArmorContents(armor);
-						pi.setStorageContents(contents);
-						// SQLデータをクリア
-						sql.clearShareInv(player, playerdata);
-						playerdata.shareinv = false;
-						itemstackcurrent.setItemMeta(MenuInventoryData.dispShareInvMeta(playerdata));
-						player.sendMessage(ChatColor.GREEN + "アイテムを取得しました。手持ちにあったアイテムはドロップしました。");
-						Bukkit.getLogger().info(Util.getName(player) + "がアイテム取り出しを実施(SQL送信成功)");
-					}
-				}
-				// 収納処理
-				else {
-					PlayerInventory pi = player.getInventory();
-					List<ItemStack> items = new ArrayList<ItemStack>();
-
-					// アイテム一覧をリストに取り出す
-					ItemStack offhand = pi.getItemInOffHand();
-					items.add(offhand);
-					ItemStack[] armor = pi.getArmorContents();
-					items.addAll(Arrays.asList(armor));
-					ItemStack[] contents = pi.getStorageContents();
-					items.addAll(Arrays.asList(contents));
-
-					// アイテム一覧をシリアル化する
-					String serial = SerializeItemList.toBase64(items);
-					if (serial == "") {
-						// 収納失敗
-						player.sendMessage(ChatColor.RESET + "" +  ChatColor.RED + "" + ChatColor.BOLD + "収納アイテムの変換に失敗しました。");
-					} else {
-						if (sql.saveShareInv(player, playerdata, serial)) {
-							// 収納成功により現所持アイテムを全て削除
-							pi.setItemInOffHand(air);
-							for (int cnt = 0; cnt < armor.length; cnt++) {
-								armor[cnt] = air;
-							}
-							pi.setArmorContents(armor);
-							for (int cnt = 0; cnt < contents.length; cnt++) {
-								contents[cnt] = air;
-							}
-							pi.setStorageContents(contents);
-
-							// インベントリ共有ボタンをトグル
-							playerdata.shareinv = true;
-							itemstackcurrent.setItemMeta(MenuInventoryData.dispShareInvMeta(playerdata));
-							player.sendMessage(ChatColor.GREEN + "アイテムを収納しました。10秒以上あとに、手持ちを空にして取り出してください。");
-							Bukkit.getLogger().info(Util.getName(player) + "がアイテム収納を実施(SQL送信成功)");
-						}
-					}
-				}
+				player.chat("/shareinv");
+				itemstackcurrent.setItemMeta(MenuInventoryData.dispShareInvMeta(playerdata));
 			}
 		}
 	}

--- a/src/com/github/unchama/seichiassist/task/HalfHourTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/HalfHourTaskRunnable.java
@@ -39,7 +39,7 @@ public class HalfHourTaskRunnable extends BukkitRunnable{
 			//プレイヤー型を取得
 			Player player = plugin.getServer().getPlayer(playerdata.uuid);
 			//プレイヤーがオンラインの時の処理
-			if(player != null){
+			if(player != null && playerdata.loaded){
 				//現在の統計量を取得
 				int mines = playerdata.totalbreaknum;
 				//現在の統計量を設定(after)
@@ -48,6 +48,10 @@ public class HalfHourTaskRunnable extends BukkitRunnable{
 				playerdata.halfhourblock.setIncrease();
 				//現在の統計量を設定（before)
 				playerdata.halfhourblock.before = mines;
+			}else if(!playerdata.loaded){
+				//debug用…このメッセージ視認後に大量集計されないかを確認する
+				plugin.getServer().getConsoleSender().sendMessage("Apple Pen !");
+				playerdata.halfhourblock.increase = 0;
 			}else{
 				//ﾌﾟﾚｲﾔｰがオフラインの時の処理
 				//前回との差を０に設定
@@ -85,11 +89,11 @@ public class HalfHourTaskRunnable extends BukkitRunnable{
 		Util.sendEveryMessage("この30分間の総破壊量は " + ChatColor.AQUA + all + ChatColor.WHITE + "個でした");
 		for(Entry<UUID,PlayerData> e : entries){
 			if(count == 1){
-				Util.sendEveryMessage("破壊量第1位は" + ChatColor.DARK_PURPLE + e.getValue().name + ChatColor.WHITE + "で" + ChatColor.AQUA + e.getValue().halfhourblock.increase + ChatColor.WHITE + "個でした");
+				Util.sendEveryMessage("破壊量第1位は" + ChatColor.DARK_PURPLE + "[ Lv" + Integer.toString(e.getValue().level) +" ]" + e.getValue().name + ChatColor.WHITE + "で" + ChatColor.AQUA + e.getValue().halfhourblock.increase + ChatColor.WHITE + "個でした");
 			}else if(count == 2){
-				Util.sendEveryMessage("破壊量第2位は" + ChatColor.BLUE + e.getValue().name+ ChatColor.WHITE + "で" + ChatColor.AQUA + e.getValue().halfhourblock.increase + ChatColor.WHITE + "個でした");
+				Util.sendEveryMessage("破壊量第2位は" + ChatColor.BLUE + "[ Lv" + Integer.toString(e.getValue().level) +" ]" + e.getValue().name+ ChatColor.WHITE + "で" + ChatColor.AQUA + e.getValue().halfhourblock.increase + ChatColor.WHITE + "個でした");
 			}else if(count == 3){
-				Util.sendEveryMessage("破壊量第3位は" + ChatColor.DARK_AQUA + e.getValue().name+ ChatColor.WHITE + "で" + ChatColor.AQUA + e.getValue().halfhourblock.increase + ChatColor.WHITE + "個でした");
+				Util.sendEveryMessage("破壊量第3位は" + ChatColor.DARK_AQUA + "[ Lv" + Integer.toString(e.getValue().level) +"]" + e.getValue().name+ ChatColor.WHITE + "で" + ChatColor.AQUA + e.getValue().halfhourblock.increase + ChatColor.WHITE + "個でした");
 			}
 			count++;
 		}

--- a/src/com/github/unchama/seichiassist/task/LoadPlayerDataTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/LoadPlayerDataTaskRunnable.java
@@ -125,6 +125,7 @@ public class LoadPlayerDataTaskRunnable extends BukkitRunnable{
 			rs = stmt.executeQuery(command);
 			while (rs.next()) {
 				//各種数値
+				playerdata.loaded = true;
  				playerdata.effectflag = rs.getBoolean("effectflag");
  				playerdata.minestackflag = rs.getBoolean("minestackflag");
  				playerdata.messageflag = rs.getBoolean("messageflag");


### PR DESCRIPTION
・/shareinvの追加
インベントリ共有ボタン押下と同効果
パーミッション不要で誰でも使える
無効化：コメントアウト
SeichiAssist.java#601 commandlist.put("shareinv",new
shareinvCommand(plugin));
※インベントリ共有ボタンも効かなくなるので要調整

・インベントリ共有後に木の棒取得
無効化：コメントアウト
shareinvCommand.java #135 player.chat("/stick");

・/warnコマンドの追加
- SeichiAssistBungeeの導入
- Bungee側パーミッションseichiassistbungee.warn
により警告文を発行出来るwarnコマンドが有効化
無効化：上記どちらか

・/seichiinfoコマンドの追加
特定プレイヤーの整地レベル、居場所を取得可能
ストーカー防止のため情報をとられたことを表示している
無効化：下記パーミッション設定
(Bungee)SeichiinfoCommand.java #15
super("seichiinfo"); → super("seichiinfo",
"seichiassistbungee.seichiinfo");
※パーミッションが無いとコマンドが使えなくなる
情報取得通知の消去：コメントアウト
(Spigot)BungeeReceiver.java #65
p.sendMessage(wanter + "からプレイヤーデータの要求があったため、データを送信しました。");

・30分ランキングの修正
ログイン直後はデータ取得まで集計しないよう変更
整地レベルを併記するよう変更
無効化：コメントアウト
HalfHourTaskRunnable.java #42, #51 playerdata.loadedの判断文の除去
#92, #94, #96 レベル表記の修正
※ログイン直後の対象除外がローカルでは再現できなかった
①整地量を膨大に設定　②ログイン　③SQL取得前にランキング稼働　④apple penメッセージが出る　⑤膨大な整地量が表示されないはず