### PR TITLE
RedMine#104,#162,#211修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 #IntelliJ IDEA
 .idea/
 *.iml
+/bin/
+/bin/

--- a/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -687,14 +687,16 @@ public class MenuInventoryData {
 		// ver0.3.2 掲示板を表示
 		itemstack = new ItemStack(Material.SIGN,1);
 		itemmeta = Bukkit.getItemFactory().getItemMeta(Material.SIGN);
-		itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "掲示板を見る");
-		lore = Arrays.asList(ChatColor.RESET + "" +  ChatColor.GREEN + "管理人へのお問い合わせは"
-				, ChatColor.RESET + "" +  ChatColor.GREEN + "掲示板に書き込みをｵﾈｶﾞｲｼﾅｽ"
-				, ChatColor.RESET + "" + ChatColor.DARK_GRAY + "クリックするとチャット欄に"
+		itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "JapanMinecraftServerリンク");
+		lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.DARK_GRAY + "クリックするとチャット欄に"
 				, ChatColor.RESET + "" + ChatColor.DARK_GRAY + "URLが表示されますので"
 				, ChatColor.RESET + "" + ChatColor.DARK_GRAY + "Tキーを押してから"
 				, ChatColor.RESET + "" + ChatColor.DARK_GRAY + "そのURLをクリックしてください"
 				);
+		//現在掲示板は存在しないので、名前を変更して「JapanMinecraftServerリンク」とする
+		//消去部分
+		//Arrays.asList(ChatColor.RESET + "" +  ChatColor.GREEN + "管理人へのお問い合わせは"
+		//, ChatColor.RESET + "" +  ChatColor.GREEN + "掲示板に書き込みをｵﾈｶﾞｲｼﾅｽ"
 		itemmeta.setLore(lore);
 		itemstack.setItemMeta(itemmeta);
 		inventory.setItem(3,itemstack);
@@ -1292,6 +1294,7 @@ public class MenuInventoryData {
 			lore.add(ChatColor.RESET + "" +  ChatColor.GREEN + "複数種類ブロック同時破壊");
 			lore.add(ChatColor.RESET + "" +  ChatColor.GRAY + "ブロックに対応するツールを無視してスキルで");
 			lore.add(ChatColor.RESET + "" +  ChatColor.GRAY + "破壊可能な全種類のブロックを同時に破壊します");
+			lore.add(ChatColor.RESET + "" + ChatColor.DARK_RED + "整地ワールドではON/OFFに関わらず同時破壊されます");
 			//ChatColor.RESET + "" +  ChatColor.DARK_GRAY + "クールダウン：0秒"
 			if(playerdata.level>=SeichiAssist.config.getMultipleIDBlockBreaklevel()){
 				lore.add(ChatColor.RESET + "" +  ChatColor.DARK_GREEN + "必要整地レベル：" + SeichiAssist.config.getMultipleIDBlockBreaklevel());

--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -631,7 +631,7 @@ public class PlayerInventoryListener implements Listener {
 
 			else if(itemstackcurrent.getType().equals(Material.BOOK_AND_QUILL)){
 				// 投票リンク表示
-				player.sendMessage(ChatColor.RED + "" + ChatColor.UNDERLINE + "https://minecraft.jp/servers/play.seichi.click/vote");
+				player.sendMessage(ChatColor.RED + "" + ChatColor.UNDERLINE + "https://minecraft.jp/servers/54d3529e4ddda180780041a7/vote");
 				player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
 				player.closeInventory();
 			}
@@ -652,9 +652,8 @@ public class PlayerInventoryListener implements Listener {
 			}
 
 			else if(itemstackcurrent.getType().equals(Material.SIGN)){
-				// 掲示板リンク表示
-				player.sendMessage(ChatColor.DARK_GRAY + "開いたら下の方までスクロールしてください\n"
-						+ ChatColor.RED + "" + ChatColor.UNDERLINE + "https://minecraft.jp/servers/play.seichi.click"
+				//JMSリンク表示
+				player.sendMessage(ChatColor.RED + "" + ChatColor.UNDERLINE + "https://minecraft.jp/servers/54d3529e4ddda180780041a7"
 						);
 				player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
 				player.closeInventory();


### PR DESCRIPTION
RedMine#104-パッシブトグル追記
　現時点ではOFFにすると追記が消えてしまう。それを修正
RedMine#162-木の棒メニュー内のリンク切れ修正
　新しいリンクに張り替えた
RedMine#211-木の棒メニューの掲示板URL表示機能のコメントアウト
　コメントアウトではなく、ボタンの表示を「JapanMinecarftServerリンク」とし、不要な部分をカットした。(この件ですが、pullrequest急いでいるようなので、まずはこの状態にして、落ち着いてから作り直します。)

以上宜しくお願いします。