### PR TITLE
インベントリ満タン通知抑制、経験値オーブが出ないバグ修正

### DIFF
--- a/src/com/github/unchama/seichiassist/SeichiAssist.java
+++ b/src/com/github/unchama/seichiassist/SeichiAssist.java
@@ -429,8 +429,8 @@ public class SeichiAssist extends JavaPlugin{
 			,new MineStackObj("step5","石レンガハーフブロック",32,Material.STEP,5,false,-1,3)
 
 			,new MineStackObj("red_nether_brick"	,"赤いネザーレンガ"	,36,Material.RED_NETHER_BRICK,0,false,-1,3)
-			
-			
+
+
 			));
 
 	public static final List<MineStackObj> minestacklistrs = new ArrayList<MineStackObj>(Arrays.asList(

--- a/src/com/github/unchama/seichiassist/breakeffect/BlizzardTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/breakeffect/BlizzardTaskRunnable.java
@@ -2,6 +2,7 @@ package com.github.unchama.seichiassist.breakeffect;
 
 import java.util.List;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -54,6 +55,10 @@ public class BlizzardTaskRunnable extends BukkitRunnable{
 				BreakUtil.BreakBlock(player, b, droploc, tool, true);
 				SeichiAssist.allblocklist.remove(b);
 			}
+		}
+		if(BreakUtil.isInventoryFull){
+			player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+			BreakUtil.isInventoryFull = false;
 		}
 		soundradius = 5;
 

--- a/src/com/github/unchama/seichiassist/breakeffect/ExplosionTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/breakeffect/ExplosionTaskRunnable.java
@@ -2,6 +2,7 @@ package com.github.unchama.seichiassist.breakeffect;
 
 import java.util.List;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -65,6 +66,10 @@ public class ExplosionTaskRunnable extends BukkitRunnable{
 				BreakUtil.BreakBlock(player, b, droploc, tool, true);
 				SeichiAssist.allblocklist.remove(b);
 			}
+		}
+		if(BreakUtil.isInventoryFull){
+			player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+			BreakUtil.isInventoryFull = false;
 		}
 	}
 

--- a/src/com/github/unchama/seichiassist/breakeffect/MeteoTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/breakeffect/MeteoTaskRunnable.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Sound;
@@ -136,7 +137,10 @@ public class MeteoTaskRunnable extends BukkitRunnable{
 				SeichiAssist.allblocklist.remove(b);
 			}
 		}
-
+		if(BreakUtil.isInventoryFull){
+			player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+			BreakUtil.isInventoryFull = false;
+		}
 	}
 	private boolean isBreakBlock(Location loc) {
 		Block b = loc.getBlock();

--- a/src/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.java
@@ -12,12 +12,16 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockExpEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+
+import zedly.zenchantments.Zenchantments;
 
 import com.github.unchama.seichiassist.ActiveSkill;
 import com.github.unchama.seichiassist.ActiveSkillEffect;
@@ -31,8 +35,6 @@ import com.github.unchama.seichiassist.task.CoolDownTaskRunnable;
 import com.github.unchama.seichiassist.task.MultiBreakTaskRunnable;
 import com.github.unchama.seichiassist.util.BreakUtil;
 import com.github.unchama.seichiassist.util.Util;
-
-import zedly.zenchantments.Zenchantments;
 
 public class PlayerBlockBreakListener implements Listener {
 	HashMap<UUID,PlayerData> playermap = SeichiAssist.playermap;
@@ -181,6 +183,10 @@ public class PlayerBlockBreakListener implements Listener {
 		if(playerdata.activeskilldata.mineflagnum == 0 || playerdata.activeskilldata.skillnum == 0 || playerdata.activeskilldata.skilltype == 0 || playerdata.activeskilldata.skilltype == ActiveSkill.ARROW.gettypenum()){
 			if(SeichiAssist.DEBUG) player.sendMessage(ChatColor.RED + "スキルオフ時の破壊");
 			BreakUtil.addItemToPlayerDirectry(player, block, mainhanditem);
+			if(BreakUtil.isInventoryFull){
+				player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+				BreakUtil.isInventoryFull = false;
+			}
 			return;
 		}
 
@@ -363,6 +369,10 @@ public class PlayerBlockBreakListener implements Listener {
 		//自身のみしか壊さない時自然に処理する
 		if(breakblocknum==0){
 			BreakUtil.BreakBlock(player, block, centerofblock, tool,false);
+			if(BreakUtil.isInventoryFull){
+				player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+				BreakUtil.isInventoryFull = false;
+			}
 			return;
 		}//スキルの処理
 		else{
@@ -538,6 +548,10 @@ public class PlayerBlockBreakListener implements Listener {
 		//自身のみしか壊さない時自然に処理する
 		if(breaklist.size()==0){
 			BreakUtil.BreakBlock(player, block, centerofblock, tool,false);
+			if(BreakUtil.isInventoryFull){
+				player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+				BreakUtil.isInventoryFull = false;
+			}
 			return;
 		}//エフェクトが指定されていないときの処理
 		else if(playerdata.activeskilldata.effectnum == 0){
@@ -546,6 +560,10 @@ public class PlayerBlockBreakListener implements Listener {
 			for(Block b:breaklist){
 				BreakUtil.BreakBlock(player, b, centerofblock, tool,true);
 				SeichiAssist.allblocklist.remove(b);
+			}
+			if(BreakUtil.isInventoryFull){
+				player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+				BreakUtil.isInventoryFull = false;
 			}
 		}
 		//通常エフェクトが指定されているときの処理(100以下の番号に割り振る）
@@ -576,4 +594,17 @@ public class PlayerBlockBreakListener implements Listener {
 			new CoolDownTaskRunnable(player,false,true,false).runTaskLater(plugin,cooldown);
 		}
 	}
+	@EventHandler
+	public void onBlockGenerteExpEvent(BlockExpEvent event){
+		int exp = event.getExpToDrop();
+		Block block = event.getBlock();
+
+		Location loc = block.getLocation();
+		if(exp > 0){
+			ExperienceOrb orb = loc.getWorld().spawn(loc, ExperienceOrb.class);
+			orb.setExperience(exp);
+		}
+	}
+
+
 }

--- a/src/com/github/unchama/seichiassist/util/BreakUtil.java
+++ b/src/com/github/unchama/seichiassist/util/BreakUtil.java
@@ -31,6 +31,7 @@ import com.github.unchama.seichiassist.data.MineStackGachaData;
 import com.github.unchama.seichiassist.data.PlayerData;
 
 public class BreakUtil {
+	public static boolean isInventoryFull = false;
 	//他のプラグインの影響があってもブロックを破壊できるのか
 	@SuppressWarnings("deprecation")
 	public static boolean canBreak(Player player ,Block breakblock) {
@@ -102,7 +103,8 @@ public class BreakUtil {
 			if(!addItemtoMineStack(player,itemstack)){
 				HashMap<Integer,ItemStack> exceededItems = player.getInventory().addItem(itemstack);
 				for(Integer i:exceededItems.keySet()){
-					player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+					//player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+					isInventoryFull = true;
 					breakblock.getWorld().dropItemNaturally(centerofblock,exceededItems.get(i));
 				}
 
@@ -1034,7 +1036,8 @@ public class BreakUtil {
 		if(!addItemtoMineStack(player,dropItem)){
 			HashMap<Integer,ItemStack> exceededItems = inventory.addItem(dropItem);
 			for(Integer i:exceededItems.keySet()){
-				player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+				//player.sendMessage(ChatColor.RED + "インベントリがいっぱいです");
+				isInventoryFull = true;
 				block.getWorld().dropItemNaturally(block.getLocation().add(0.5, 0.5, 0.5),exceededItems.get(i));
 			}
 
@@ -1044,4 +1047,5 @@ public class BreakUtil {
 
 
 	}
+
 }


### PR DESCRIPTION
インベントリ満タンの通知を抑制しました。単爆発1回につき1回の表示に抑えてあります。
(つまりトムボウイだと3回でます)
また、鉱石破壊時に、鉱石は手に入るが経験値オーブが出現しないというバグ(めがさんが言ってたやつ)を修正しました。