### PR TITLE
 FIX and Development

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -484,3 +484,5 @@ space_height: 5
 road_blockid: 98
 #道のブロックダメージ値
 road_blockdamage: 0
+#貢献度1当たりのマナ増加量
+contribute_added_mana: 10

--- a/config.yml
+++ b/config.yml
@@ -484,10 +484,9 @@ space_height: 5
 road_blockid: 98
 #道のブロックダメージ値
 road_blockdamage: 0
-<<<<<<< HEAD
+
 #貢献度1当たりのマナ増加量
 contribute_added_mana: 10
-=======
 
 #お正月イベント関連(ここの設定を変更することで毎年使いまわしが可能です。)
 #日付は必ず"西暦4桁-月2桁-日2桁"で入力すること!!
@@ -503,4 +502,3 @@ NewYearEvent:
   NewYearBagDropProbability: 500
   #(お年玉袋ItemNBT識別用);基本的に来年度の年を入力してください。
   NewYear: "2018"
->>>>>>> refs/remotes/unchama/master

--- a/plugin.yml
+++ b/plugin.yml
@@ -58,3 +58,8 @@ commands:
       usage: /<command>
       permission: multiseichiplugin.halfguard
       permission-message: You don't have <permission>
+  contribute:
+      description: This is a Contribute command.
+      usage: /<command> <help/add/remove> <playername> <point>
+      permission: multiseichiplugin.contribute
+      permission-message: You don't have <permission>

--- a/src/com/github/unchama/seichiassist/Config.java
+++ b/src/com/github/unchama/seichiassist/Config.java
@@ -1,11 +1,12 @@
 package com.github.unchama.seichiassist;
 
-import com.github.unchama.seichiassist.data.GachaData;
-import com.github.unchama.seichiassist.util.Util;
+import java.util.List;
+
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
-import java.util.List;
+import com.github.unchama.seichiassist.data.GachaData;
+import com.github.unchama.seichiassist.util.Util;
 
 public class Config{
 	private static FileConfiguration config;
@@ -206,5 +207,8 @@ public class Config{
 
 	public int getRoadBlockDamage() {
 		return config.getInt("road_blockdamage");
+	}
+	public int getContributeAddedMana() {
+		return config.getInt("contribute_added_mana");
 	}
 }

--- a/src/com/github/unchama/seichiassist/Config.java
+++ b/src/com/github/unchama/seichiassist/Config.java
@@ -208,10 +208,10 @@ public class Config{
 	public int getRoadBlockDamage() {
 		return config.getInt("road_blockdamage");
 	}
-<<<<<<< HEAD
+
 	public int getContributeAddedMana() {
 		return config.getInt("contribute_added_mana");
-=======
+	}
 
 	public String getGivingNewYearSobaDay() {
 		return config.getString("NewYearEvent.GivingNewYearSobaDay");
@@ -235,6 +235,5 @@ public class Config{
 
 	public String getNewYear() {
 		return config.getString("NewYearEvent.NewYear");
->>>>>>> refs/remotes/unchama/master
 	}
 }

--- a/src/com/github/unchama/seichiassist/SeichiAssist.java
+++ b/src/com/github/unchama/seichiassist/SeichiAssist.java
@@ -25,6 +25,7 @@ import org.bukkit.scheduler.BukkitTask;
 import com.github.unchama.seichiassist.bungee.BungeeReceiver;
 import com.github.unchama.seichiassist.commands.AchieveCommand;
 import com.github.unchama.seichiassist.commands.HalfBlockProtectCommand;
+import com.github.unchama.seichiassist.commands.contributeCommand;
 import com.github.unchama.seichiassist.commands.effectCommand;
 import com.github.unchama.seichiassist.commands.gachaCommand;
 import com.github.unchama.seichiassist.commands.lastquitCommand;
@@ -635,6 +636,7 @@ public class SeichiAssist extends JavaPlugin{
 		commandlist.put("mebius",new mebiusCommand(plugin));
 		commandlist.put("unlockachv", new AchieveCommand(plugin));
 		commandlist.put("halfguard", new HalfBlockProtectCommand(plugin));
+		commandlist.put("contribute", new contributeCommand(plugin));
 
 		//リスナーの登録
 		getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);

--- a/src/com/github/unchama/seichiassist/commands/contributeCommand.java
+++ b/src/com/github/unchama/seichiassist/commands/contributeCommand.java
@@ -1,0 +1,112 @@
+package com.github.unchama.seichiassist.commands;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+
+import com.github.unchama.seichiassist.SeichiAssist;
+import com.github.unchama.seichiassist.Sql;
+import com.github.unchama.seichiassist.data.PlayerData;
+import com.github.unchama.seichiassist.util.Util;
+
+public class contributeCommand implements TabExecutor {
+	SeichiAssist plugin;
+
+	public contributeCommand(SeichiAssist _plugin){
+		plugin = _plugin;
+	}
+	@Override
+	public List<String> onTabComplete(CommandSender arg0, Command arg1,
+			String arg2, String[] arg3) {
+		// TODO 自動生成されたメソッド・スタブ
+		return null;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+
+
+		Sql sql = SeichiAssist.plugin.sql;
+
+
+		//受け取るプレイヤーの情報を取得
+		Player givenplayer = Bukkit.getServer().getPlayer(args[1]);
+
+		if(args.length == 0){
+			//コマンド長が0の時の処理
+			sender.sendMessage(ChatColor.GREEN + "/contribute <add/remove> <playername> <point>");
+			return true;
+
+		}else if(args[0].equalsIgnoreCase("add") && args.length == 3){
+
+			//sqlをusernameで操作
+			if (sql.setContribute((CommandSender)sender, args[1], Util.toInt(args[2]))) {
+				sender.sendMessage(ChatColor.GREEN + args[1] + "に貢献度ポイント" + args[2] + "を追加しました");
+
+				//指定プレイヤーがオンラインの場合即時反映
+				if (givenplayer != null) {
+					//UUIDを取得
+					UUID givenuuid = givenplayer.getUniqueId();
+					//playerdataを取得
+					PlayerData givenplayerdata = SeichiAssist.playermap.get(givenuuid);
+
+					//splを直接書き換えているのでplayerdataを同じ数値だけ変化させてから計算させる
+					givenplayerdata.contribute_point += Util.toInt(args[2]);
+
+					givenplayerdata.isContribute(givenplayer, Util.toInt(args[2]));
+				}
+			}
+			return true;
+		}else if(args[0].equalsIgnoreCase("remove") && args.length == 3){
+
+			//sqlをusernameで操作
+			if (sql.setContribute((CommandSender)sender, args[1], (-1 * Util.toInt(args[2])))) {
+				sender.sendMessage(ChatColor.GREEN + args[1] + "の貢献度ポイントを" + args[2] + "減少させました");
+
+				//指定プレイヤーがオンラインの場合即時反映
+				if (givenplayer != null) {
+					//UUIDを取得
+					UUID givenuuid = givenplayer.getUniqueId();
+					//playerdataを取得
+					PlayerData givenplayerdata = SeichiAssist.playermap.get(givenuuid);
+
+					//splを直接書き換えているのでplayerdataを同じ数値だけ変化させてから計算させる
+					givenplayerdata.contribute_point += (-1 * Util.toInt(args[2]));
+
+					givenplayerdata.isContribute(givenplayer, (-1 * Util.toInt(args[2])));
+				}
+				return true;
+			}
+		}else if(args[0].equalsIgnoreCase("help")){
+			sender.sendMessage(ChatColor.YELLOW + "" + ChatColor.BOLD +"[コマンドリファレンス]");
+			sender.sendMessage(ChatColor.RED + "/contribute add <プレイヤー名> <増加分ポイント>");
+			sender.sendMessage("指定されたプレイヤーの貢献度ptを指定分増加させます");
+
+			sender.sendMessage(ChatColor.RED + "/contribute remove <プレイヤー名> <減少分ポイント>");
+			sender.sendMessage("指定されたプレイヤーの貢献度ptを指定分減少させます(入力ミス回避用)");
+
+			return true;
+		}else if(args[0].equalsIgnoreCase("add")){
+			sender.sendMessage(ChatColor.GREEN + "/contribute add <playername> <point>");
+
+			return true;
+		}else if(args[0].equalsIgnoreCase("remove")){
+			sender.sendMessage(ChatColor.GREEN + "/contribute remove <playername> <point>");
+
+			return true;
+		}else if(args.length == 2){
+			//コマンド長が2の時の処理
+			sender.sendMessage(ChatColor.GREEN + "/contribute <add/remove> <playername> <point>");
+
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/com/github/unchama/seichiassist/data/Mana.java
+++ b/src/com/github/unchama/seichiassist/data/Mana.java
@@ -2,6 +2,8 @@ package com.github.unchama.seichiassist.data;
 
 
 
+import java.util.UUID;
+
 import net.md_5.bungee.api.ChatColor;
 
 import org.bukkit.boss.BarColor;
@@ -35,7 +37,7 @@ public class Mana {
 		//現在のレベルでのマナ上限値を計算しバーに表示
 		//mの値は既に得られているはず。
 		this.loadflag = true;
-		this.calcMaxMana(level);
+		this.calcMaxMana(player, level);
 		displayMana(player,level);
 
 	}
@@ -49,7 +51,7 @@ public class Mana {
 		manabar = player.getServer().createBossBar(ChatColor.AQUA + "" + ChatColor.BOLD + "マナ(" + Util.Decimal(m) + "/" + max + ")", BarColor.BLUE, BarStyle.SOLID);
 
 		if(m/max < 0.0 || m/max > 1.0){
-			reset(level);
+			reset(player, level);
 			player.sendMessage(ChatColor.RED + "不正な値がマナとして保存されていたためリセットしました。");
 		}
 		if (!(max == 0||max < 0)){
@@ -57,8 +59,8 @@ public class Mana {
 		manabar.addPlayer(player);
 		}
 	}
-	private void reset(int level) {
-		this.calcMaxMana(level);
+	private void reset(Player player, int level) {
+		this.calcMaxMana(player, level);
 		if(this.m < 0.0)this.m = 0;
 		if(this.m > max)this.m = max;
 	}
@@ -69,7 +71,7 @@ public class Mana {
 	public void increaseMana(double i,Player player,int level){
 		this.m += i;
 		if(m > max) m = max;
-		displayMana(player,level);
+		displayMana(player, level);
 	}
 	public void decreaseMana(double d,Player player,int level){
 		this.m -= d;
@@ -89,11 +91,17 @@ public class Mana {
 	}
 	//レベルアップするときに実行したい関数
 	public void LevelUp(Player player,int level){
-		calcMaxMana(level);
+		calcMaxMana(player, level);
 		fullMana(player,level);
 	}
 	//マナ最大値を計算する処理
-	public void calcMaxMana(int level){
+	public void calcMaxMana(Player player, int level){
+
+		//UUIDを取得
+		UUID uuid = player.getUniqueId();
+		//playerdataを取得
+		PlayerData playerdata = SeichiAssist.playermap.get(uuid);
+
 		if(SeichiAssist.DEBUG){
 			max = 100000;
 			return;
@@ -117,6 +125,9 @@ public class Mana {
 			}
 			t_max += increase;
 		}
+		//貢献度ptの上昇値
+		t_max += playerdata.added_mana * SeichiAssist.config.getContributeAddedMana();
+
 		this.max = t_max;
 		return;
 	}
@@ -129,7 +140,13 @@ public class Mana {
 	 * 最大マナ
 	 */
 	//マナ最大値を計算する処理
-	public double calcMaxManaOnly(int level){
+	public double calcMaxManaOnly(Player player, int level){
+
+		//UUIDを取得
+		UUID uuid = player.getUniqueId();
+		//playerdataを取得
+		PlayerData playerdata = SeichiAssist.playermap.get(uuid);
+
 		/*
 		if(SeichiAssist.DEBUG){
 			max = 100000;
@@ -155,6 +172,9 @@ public class Mana {
 			}
 			t_max += increase;
 		}
+		//貢献度ptの上昇値
+		t_max += playerdata.added_mana * SeichiAssist.config.getContributeAddedMana();
+
 		max=t_max;
 		return t_max;
 	}
@@ -175,5 +195,4 @@ public class Mana {
 	public boolean isloaded() {
 		return this.loadflag;
 	}
-
 }

--- a/src/com/github/unchama/seichiassist/data/PlayerData.java
+++ b/src/com/github/unchama/seichiassist/data/PlayerData.java
@@ -180,15 +180,13 @@ public class PlayerData {
 	public int VotingFairyRecoveryValue;
 	public int giveApple;
 
-<<<<<<< HEAD
 	//貢献度pt
 	public int added_mana;
 	public int contribute_point;
-=======
+
 	//正月イベント用
 	public boolean hasNewYearSobaGive;
 	public int newYearBagAmount;
->>>>>>> refs/remotes/unchama/master
 
 	public PlayerData(Player player){
 		//初期値を設定
@@ -271,13 +269,11 @@ public class PlayerData {
 		this.VotingFairyStartTime = null;
 		this.VotingFairyEndTime = null;
 
-<<<<<<< HEAD
 		this.added_mana = 0;
 		this.contribute_point = 0;
-=======
+
 		this.hasNewYearSobaGive = false;
 		this.newYearBagAmount = 0;
->>>>>>> refs/remotes/unchama/master
 	}
 
 	//join時とonenable時、プレイヤーデータを最新の状態に更新

--- a/src/com/github/unchama/seichiassist/data/PlayerData.java
+++ b/src/com/github/unchama/seichiassist/data/PlayerData.java
@@ -180,6 +180,10 @@ public class PlayerData {
 	public int VotingFairyRecoveryValue;
 	public int giveApple;
 
+	//貢献度pt
+	public int added_mana;
+	public int contribute_point;
+
 	public PlayerData(Player player){
 		//初期値を設定
 		this.loaded = false;
@@ -260,6 +264,9 @@ public class PlayerData {
 		this.giveApple = 0;
 		this.VotingFairyStartTime = null;
 		this.VotingFairyEndTime = null;
+
+		this.added_mana = 0;
+		this.contribute_point = 0;
 	}
 
 	//join時とonenable時、プレイヤーデータを最新の状態に更新
@@ -846,17 +853,36 @@ public class PlayerData {
 			this.VotingFairyStartTime = startTime;
 			this.VotingFairyEndTime = EndTime;
 		}
+	}
+
+	public void isVotingFairy(Player p){
 		//効果は継続しているか
-		if( this.canVotingFairyUse == true && Util.isVotingFairyPeriod(this.VotingFairyStartTime, this.VotingFairyEndTime) == false ){
-			this.canVotingFairyUse = false ;
-			p.sendMessage(ChatColor.LIGHT_PURPLE + "" + ChatColor.BOLD + "妖精は何処かへ行ってしまったようだ...");
+			if( this.canVotingFairyUse == true && Util.isVotingFairyPeriod(this.VotingFairyStartTime, this.VotingFairyEndTime) == false ){
+				this.canVotingFairyUse = false ;
+				p.sendMessage(ChatColor.LIGHT_PURPLE + "" + ChatColor.BOLD + "妖精は何処かへ行ってしまったようだ...");
+			}
+			else if(this.canVotingFairyUse == true){
+				p.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD + "≪マナの妖精≫ " + ChatColor.RESET + "おかえり。" + p.getName() );
+				if(this.hasVotingFairyMana > 0)
+					p.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD + "≪マナの妖精≫ " + ChatColor.RESET + "僕はまだ君のマナを回復させられるよ" );
+				else
+					p.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD + "≪マナの妖精≫ " + ChatColor.RESET + "ガチャりんごがもう無いからまた渡してくれると嬉しいな" );
+			}
+	}
+
+	public void isContribute(Player p,int addMana){
+		Mana mana = new Mana();
+
+		//負数(入力ミスによるやり直し中プレイヤーがオンラインだった場合)の時
+		if(addMana < 0){
+			p.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + "入力者のミスによって得た不正なマナを" + (-10*addMana) +"分減少させました.");
+			p.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + "申し訳ございません.");
+		}else{
+			p.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + "運営からあなたの整地鯖への貢献報酬として");
+			p.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + "マナの上限値が" + 10*addMana + "上昇しました．(永久)");
 		}
-		else if(this.canVotingFairyUse == true){
-			p.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD + "≪マナの妖精≫ " + ChatColor.RESET + "おかえり。" + p.getName() );
-			if(this.hasVotingFairyMana > 0)
-				p.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD + "≪マナの妖精≫ " + ChatColor.RESET + "僕はまだ君のマナを回復させられるよ" );
-			else
-				p.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD + "≪マナの妖精≫ " + ChatColor.RESET + "ガチャりんごがもう無いからまた渡してくれると嬉しいな" );
-		}
+		this.added_mana += addMana;
+
+		mana.calcMaxMana(p, this.level);
 	}
 }

--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -1742,6 +1742,11 @@ public class PlayerInventoryListener implements Listener {
 						player.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD + "" + ActiveSkill.getActiveSkillName(skilltype ,skilllevel) + "を解除しました");
 						player.playSound(player.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1, (float)1.2);
 						playerdata.activeskilldata.updataActiveSkillPoint(player,playerdata.level);
+						if(playerdata.activeskilldata.arrowskill == 9 && playerdata.activeskilldata.multiskill == 9 && playerdata.activeskilldata.watercondenskill == 9 && playerdata.activeskilldata.lavacondenskill == 9){
+							player.sendMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + "全てのスキルを習得し、アサルト・アーマーを解除しました");
+							Util.sendEverySound(Sound.ENTITY_ENDERDRAGON_DEATH, 1, (float)1.2);
+							Util.sendEveryMessage(ChatColor.GOLD + "" + ChatColor.BOLD + playerdata.name + "が全てのスキルを習得し、アサルトアーマーを解除しました！");
+						}
 						player.openInventory(ActiveSkillInventoryData.getActiveSkillMenuData(player));
 					}
 				}else if(itemmeta.getDisplayName().contains("ラヴァ・コンデンセーション")){
@@ -1795,7 +1800,7 @@ public class PlayerInventoryListener implements Listener {
 						player.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD + "" + ActiveSkill.getActiveSkillName(skilltype ,skilllevel) + "を解除しました");
 						player.playSound(player.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1, (float)1.2);
 						playerdata.activeskilldata.updataActiveSkillPoint(player,playerdata.level);
-						if(playerdata.activeskilldata.arrowskill == 9 && playerdata.activeskilldata.breakskill == 9 && playerdata.activeskilldata.multiskill == 9){
+						if(playerdata.activeskilldata.arrowskill == 9 && playerdata.activeskilldata.multiskill == 9 && playerdata.activeskilldata.watercondenskill == 9 && playerdata.activeskilldata.lavacondenskill == 9){
 							player.sendMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + "全てのスキルを習得し、アサルト・アーマーを解除しました");
 							Util.sendEverySound(Sound.ENTITY_ENDERDRAGON_DEATH, 1, (float)1.2);
 							Util.sendEveryMessage(ChatColor.GOLD + "" + ChatColor.BOLD + playerdata.name + "が全てのスキルを習得し、アサルトアーマーを解除しました！");

--- a/src/com/github/unchama/seichiassist/task/LoadPlayerDataTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/LoadPlayerDataTaskRunnable.java
@@ -252,9 +252,13 @@ public class LoadPlayerDataTaskRunnable extends BukkitRunnable{
 				//投票
 				playerdata.canVotingFairyUse = rs.getBoolean("canVotingFairyUse");
 				//playerdata.VotingFairyTime = rs.getLong("VotingFairyTime");
-				playerdata.SetVotingFairyTime(rs.getString("newVotingFairyTime"),p);
 				playerdata.VotingFairyRecoveryValue = rs.getInt("VotingFairyRecoveryValue");
 				playerdata.hasVotingFairyMana = rs.getInt("hasVotingFairyMana");
+				playerdata.SetVotingFairyTime(rs.getString("newVotingFairyTime"),p);
+
+
+				playerdata.contribute_point = rs.getInt("contribute_point");
+				playerdata.added_mana = rs.getInt("added_mana");
 
  				// 1周年記念
  				if (playerdata.anniversary = rs.getBoolean("anniversary")) {
@@ -320,6 +324,16 @@ public class LoadPlayerDataTaskRunnable extends BukkitRunnable{
 		//更新したplayerdataをplayermapに追加
 		playermap.put(uuid, playerdata);
 		plugin.getServer().getConsoleSender().sendMessage(ChatColor.GREEN + p.getName() + "のプレイヤーデータ読込完了");
+
+		//playerdataが読み込み終えた時に投票妖精のマナが継続しているかを確認しプレイヤーに告知
+		playerdata.isVotingFairy(p);
+
+		//貢献度pt増加によるマナ増加があるかどうか
+		if(playerdata.added_mana < playerdata.contribute_point){
+			int addMana;
+			addMana = playerdata.contribute_point - playerdata.added_mana;
+			playerdata.isContribute(p, addMana);
+		}
 
 		return;
 	}

--- a/src/com/github/unchama/seichiassist/task/ManaRegeneTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/ManaRegeneTaskRunnable.java
@@ -21,7 +21,7 @@ public class ManaRegeneTaskRunnable extends BukkitRunnable {
 		Mana mana = pd.activeskilldata.mana;
 		int lv = pd.level;
 		// 最大マナを取得する
-		double max = mana.calcMaxManaOnly(pd.level);
+		double max = mana.calcMaxManaOnly(p, pd.level);
 		// マナを1%回復する
 		mana.increaseMana(max * 0.01, p, lv);
 	}

--- a/src/com/github/unchama/seichiassist/task/PlayerDataSaveTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/PlayerDataSaveTaskRunnable.java
@@ -221,7 +221,10 @@ public class PlayerDataSaveTaskRunnable extends BukkitRunnable{
 				+ ",canVotingFairyUse = " + Boolean.toString(playerdata.canVotingFairyUse)
 				+ ",newVotingFairyTime = '" + playerdata.VotingFairyTimeToString() + "'"
 				+ ",VotingFairyRecoveryValue = " + Integer.toString(playerdata.VotingFairyRecoveryValue)
-				+ ",hasVotingFairyMana = " + Integer.toString(playerdata.hasVotingFairyMana);
+				+ ",hasVotingFairyMana = " + Integer.toString(playerdata.hasVotingFairyMana)
+
+				//貢献度pt
+				+",added_mana = " + Integer.toString(playerdata.added_mana);
 
 				//実績のフラグ(BitSet)保存用変換処理
 				long[] TitleArray = playerdata.TitleFlags.toLongArray();
@@ -236,7 +239,6 @@ public class PlayerDataSaveTaskRunnable extends BukkitRunnable{
 			command += ",right_" + i + " = " + Integer.toString(playerdata.getTemplateMap().get(i).getRightAmount());
 			command += ",left_" + i + " = " + Integer.toString(playerdata.getTemplateMap().get(i).getLeftAmount());
 		}
-
 
 		ActiveSkillEffect[] activeskilleffect = ActiveSkillEffect.values();
 		for(int i = 0; i < activeskilleffect.length ; i++){
@@ -301,5 +303,4 @@ public class PlayerDataSaveTaskRunnable extends BukkitRunnable{
  			return;
  		}*/
 	}
-
 }

--- a/src/com/github/unchama/seichiassist/task/PlayerDataSaveTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/PlayerDataSaveTaskRunnable.java
@@ -240,13 +240,10 @@ public class PlayerDataSaveTaskRunnable extends BukkitRunnable{
 			command += ",left_" + i + " = " + Integer.toString(playerdata.getTemplateMap().get(i).getLeftAmount());
 		}
 
-<<<<<<< HEAD
-=======
 		//正月イベント
 		command += ",hasNewYearSobaGive = " + Boolean.toString(playerdata.hasNewYearSobaGive);
 		command += ",newYearBagAmount = " + Integer.toString(playerdata.newYearBagAmount);
 
->>>>>>> refs/remotes/unchama/master
 		ActiveSkillEffect[] activeskilleffect = ActiveSkillEffect.values();
 		for(int i = 0; i < activeskilleffect.length ; i++){
 			String sqlname = activeskilleffect[i].getsqlName();

--- a/src/com/github/unchama/seichiassist/task/VotingFairyTaskRunnable.java
+++ b/src/com/github/unchama/seichiassist/task/VotingFairyTaskRunnable.java
@@ -60,14 +60,14 @@ public class VotingFairyTaskRunnable {
 
 			//プレイヤーが90レベル未満のとき
 			if(playerdata.level < 90){
-				playerdata.hasVotingFairyMana = playerdata.giveApple * 300;
+				playerdata.hasVotingFairyMana += playerdata.giveApple * 300;
 			}
 			//175未満のとき
 			else if(playerdata.level < 175){
-				playerdata.hasVotingFairyMana = playerdata.giveApple * 200;
+				playerdata.hasVotingFairyMana += playerdata.giveApple * 200;
 			}
 			else{
-				playerdata.hasVotingFairyMana = playerdata.giveApple * 100;
+				playerdata.hasVotingFairyMana += playerdata.giveApple * 100;
 			}
 			playerdata.minestack.setNum(227, playerdata.minestack.getNum(227) - playerdata.giveApple);
 			player.playSound(player.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1, (float)1.2) ;


### PR DESCRIPTION
FIX

マナ妖精に渡したリンゴが加算ではなく代入になっていたのを修正
ログイン時のマナの妖精メッセージを修正
ダイヤモンドダスト,ラヴァ・コンデンセーションの解放時に不正にアサルトアーマー解除のメッセージが流れることがあったのを修正

Development

貢献度ptをコマンド(以下参照)によってプレイヤーに与えその数値によってプレイヤーのマナを恒久的に変化させる機能を追加
マナの変化倍率はconfigでいつでも変更可能

[コマンドリファレンス]
/contribute help
使い方を表示,以下に示す
/contribute add <playername> <point>
<playername>で指定したプレイヤーに対して<point>で指定した数だけ貢献度ptを加算する
加算したプレイヤーがオンラインだった場合、即時反映できる
オフラインだった場合には次にログインした時に反映される
/contribute remove <playername> <point>
<playername>で指定したプレイヤーに対して<point>で指定した数だけ貢献度ptを減算する
反映タイミングはaddと同様,入力ミス回避用