### PR TITLE
[FIX]前提スキルの表示修正

### DIFF
--- a/src/com/github/unchama/seichiassist/data/ActiveSkillInventoryData.java
+++ b/src/com/github/unchama/seichiassist/data/ActiveSkillInventoryData.java
@@ -776,7 +776,7 @@ public class ActiveSkillInventoryData {
 					, ChatColor.RESET + "" +  ChatColor.DARK_GRAY + "クールダウン：なし"
 					, ChatColor.RESET + "" +  ChatColor.BLUE + "消費マナ：100"
 					, ChatColor.RESET + "" +  ChatColor.YELLOW + "必要アクティブスキルポイント：70"
-					, ChatColor.RESET + "" +  ChatColor.DARK_RED + "前提スキル：ダイアモンド・ダスト"
+					, ChatColor.RESET + "" +  ChatColor.DARK_RED + "前提スキル：エクスプロージョン"
 					, ChatColor.RESET + "" +  ChatColor.AQUA + "" + ChatColor.UNDERLINE + "クリックで解除");
 			itemmeta.setLore(lore);
 			itemstack.setItemMeta(itemmeta);


### PR DESCRIPTION
ラヴァ・コンデンセーションの前提スキルがダイヤモンド・ダストと表示されていたが、
エクスプロージョンが前提スキルなので修正