### PR TITLE
スターレベルの微修正

### DIFF
--- a/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
-import com.github.unchama.seasonalevents.events.valentine.*;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -74,7 +73,7 @@ public class MenuInventoryData {
 		skullmeta.addEnchant(Enchantment.DIG_SPEED, 100, false);
 		skullmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + playerdata.name + "の統計データ");
 		lore.clear();
-		if(playerdata.starlevel == 0){
+		if(playerdata.starlevel <= 0){
 			lore.add(ChatColor.RESET + "" +  ChatColor.AQUA + "整地レベル:" + playerdata.level);
 		}else{
 			lore.add(ChatColor.RESET + "" +  ChatColor.AQUA + "整地レベル:" + playerdata.level + "☆" + playerdata.starlevel);

--- a/src/com/github/unchama/seichiassist/data/PlayerData.java
+++ b/src/com/github/unchama/seichiassist/data/PlayerData.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import com.github.unchama.seichiassist.event.*;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -397,11 +396,11 @@ public class PlayerData {
 	public void setDisplayName(Player p) {
 		String displayname = Util.getName(p);
 		//スターレベル用の計算
-		starlevel = totalbreaknum / 87115000 ;
+		starlevel = ( totalbreaknum / 87115000 ) - 1 ;
 
 		//表示を追加する処理
 		if(displayTitle1No == 0 && displayTitle2No == 0 && displayTitle3No == 0){
-			if(starlevel == 0){
+			if(starlevel <= 0){
 				displayname =  "[ Lv" + level + " ]" + displayname + ChatColor.WHITE;
 			}else{
 				displayname =  "[Lv" + level + "☆" + starlevel + "]" + displayname + ChatColor.WHITE;


### PR DESCRIPTION
Lv200(約8000万)の時は☆0(表示なし)で、以降追加でLv200分(約8000万)掘る度にスターレベルが上がる、という仕様を想定していたけどLv200上がりたての時点で☆1になっていたので修正